### PR TITLE
Feature - Add GitHub markdown styling integration and theme-aware export support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,1 @@
-{
-  "offlineMarkdownViewer.preview.customCssPath": "docs/custom-css/test-preview.css"
-}
+{}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` to import CSS directly from the installed `bierner.markdown-preview-github-styles` extension
+- Make the preview/export markdown root compatible with GitHub-style `.markdown-body` selectors while keeping OMV chrome outside that styled content root
+- Extend the preview styling command and docs so installed GitHub styling can be enabled without copying versioned extension CSS paths
+
 ## 0.2.0
 
 - Add `offlineMarkdownViewer.preview.globalCustomCssPath` for user-level preview styling and compose it with workspace- and folder-level `preview.customCssPath`

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These VS Code settings control rendering, safety, and performance:
 - `offlineMarkdownViewer.externalLinks.confirm` (default: `true`): confirm before opening external links.
 - `offlineMarkdownViewer.preview.autoOpen` (default: `true`): auto-open/reuse preview when a Markdown editor becomes active.
 - `offlineMarkdownViewer.preview.allowRemoteImages` (default: `false`): allow loading remote `http(s)` images in preview. When off, remote images are shown as a download action and cached locally for preview use.
+- `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` (default: `false`): load CSS from the installed `bierner.markdown-preview-github-styles` extension before any configured custom CSS, while respecting that extension's `colorTheme`, `lightTheme`, and `darkTheme` settings.
 - `offlineMarkdownViewer.preview.maxImageMB` (default: `8`): maximum local image size loaded into preview.
 - `offlineMarkdownViewer.export.embedImages` (default: `false`): embed local images as data URIs for HTML export (privacy warning shown).
 - `offlineMarkdownViewer.performance.debounceMs` (default: `120`): debounce delay for live preview updates.
@@ -90,28 +91,37 @@ These VS Code settings control rendering, safety, and performance:
 
 ## Custom CSS
 
+If you already have **Markdown Preview Github Styling** installed, the simplest GitHub-style setup is to enable `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` or run **Offline Markdown Preview: Set Custom CSS** and choose the installed GitHub styling option.
+
 Use `offlineMarkdownViewer.preview.globalCustomCssPath` in user settings to apply a stylesheet everywhere, then optionally layer `offlineMarkdownViewer.preview.customCssPath` in a workspace for repo-specific tweaks.
 
-If both are set, the global stylesheet is injected first and the workspace stylesheet is injected second, so workspace rules win on conflicts.
+Preview styles are applied in this order:
 
-You can also run **Offline Markdown Preview: Set Custom CSS** from the Command Palette to pick a global or workspace stylesheet without editing settings JSON manually.
+1. Offline Markdown Preview base CSS
+2. Installed GitHub Markdown Preview Styling CSS, if enabled
+3. Global custom CSS
+4. Workspace or folder custom CSS
+
+If both custom CSS settings are set, the global stylesheet is injected first and the workspace stylesheet is injected second, so workspace rules win on conflicts.
+
+You can also run **Offline Markdown Preview: Set Custom CSS** from the Command Palette to enable installed GitHub styling or pick a global/workspace stylesheet without editing settings JSON manually.
 
 For a full setup guide, example CSS, and GitHub-style walkthrough, see [docs/custom-css/README.md](docs/custom-css/README.md).
 
 ## Commands
 
-| Command                                                   | Purpose                                          |
-| --------------------------------------------------------- | ------------------------------------------------ |
-| `Offline Markdown Preview: Open Preview`                  | Open the Markdown preview panel                  |
-| `Offline Markdown Preview: Open Preview To Side`          | Open the preview beside the active editor        |
-| `Offline Markdown Preview: Export HTML`                   | Export the current preview/document as HTML      |
-| `Offline Markdown Preview: Export PDF`                    | Export the current preview/document as PDF       |
-| `Offline Markdown Preview: Set Custom CSS`                | Pick or clear a global/workspace custom CSS file |
-| `Offline Markdown Preview: Show Remote Image Cache Usage` | Show current remote-image cache size/file counts |
-| `Offline Markdown Preview: Clear Remote Image Cache`      | Delete cached remote images used by preview      |
-| `Offline Markdown Preview: Toggle Scroll Sync`            | Enable/disable editor <-> preview scroll sync    |
-| `Offline Markdown Preview: Copy Heading Link`             | Copy a heading anchor link (outline context)     |
-| `Offline Markdown Preview: Quick Pick Heading`            | Jump to a heading via quick pick                 |
+| Command                                                   | Purpose                                                 |
+| --------------------------------------------------------- | ------------------------------------------------------- |
+| `Offline Markdown Preview: Open Preview`                  | Open the Markdown preview panel                         |
+| `Offline Markdown Preview: Open Preview To Side`          | Open the preview beside the active editor               |
+| `Offline Markdown Preview: Export HTML`                   | Export the current preview/document as HTML             |
+| `Offline Markdown Preview: Export PDF`                    | Export the current preview/document as PDF              |
+| `Offline Markdown Preview: Set Custom CSS`                | Enable installed GitHub styling or configure custom CSS |
+| `Offline Markdown Preview: Show Remote Image Cache Usage` | Show current remote-image cache size/file counts        |
+| `Offline Markdown Preview: Clear Remote Image Cache`      | Delete cached remote images used by preview             |
+| `Offline Markdown Preview: Toggle Scroll Sync`            | Enable/disable editor <-> preview scroll sync           |
+| `Offline Markdown Preview: Copy Heading Link`             | Copy a heading anchor link (outline context)            |
+| `Offline Markdown Preview: Quick Pick Heading`            | Jump to a heading via quick pick                        |
 
 ## Remote Image Cache
 
@@ -137,7 +147,7 @@ Preview-local shortcuts (when focus is inside the preview webview):
 - **Sanitization can be disabled** for advanced cases, but this is unsafe for untrusted Markdown/HTML content.
 - **Paths outside the workspace may be blocked** for preview safety when resolving local resources.
 - **Large images are capped** by `offlineMarkdownViewer.preview.maxImageMB` to avoid excessive memory usage in preview.
-- **Custom CSS supports two scopes**: `offlineMarkdownViewer.preview.globalCustomCssPath` accepts an explicitly configured absolute `.css` file from user settings, while `offlineMarkdownViewer.preview.customCssPath` accepts only workspace- or folder-local `.css` files. When both are set, workspace or folder CSS is applied after the global stylesheet and takes precedence.
+- **Preview styling supports multiple layers**: `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` imports CSS from the installed `bierner.markdown-preview-github-styles` extension, `offlineMarkdownViewer.preview.globalCustomCssPath` accepts an explicitly configured absolute `.css` file from user settings, and `offlineMarkdownViewer.preview.customCssPath` accepts only workspace- or folder-local `.css` files. Workspace or folder CSS is applied last and takes precedence.
 - **PDF export behavior depends on the VS Code/webview print route** and may vary slightly by platform.
 
 ## Troubleshooting
@@ -147,6 +157,7 @@ Preview-local shortcuts (when focus is inside the preview webview):
 - **Images missing**: check workspace path restrictions and `offlineMarkdownViewer.preview.maxImageMB` for large local images.
 - **Downloaded remote images not showing**: run **Show Remote Image Cache Usage** and verify cache directories exist/readable, then retry or clear cache.
 - **Custom CSS not applied**: ensure `offlineMarkdownViewer.preview.globalCustomCssPath` points to an absolute `.css` file you explicitly opted into in user settings, or `offlineMarkdownViewer.preview.customCssPath` points to a workspace- or folder-local `.css` file. Workspace/folder CSS overrides global CSS on conflicts.
+- **Installed GitHub styling not applied**: verify `bierner.markdown-preview-github-styles` is installed and `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` is enabled.
 - **External links are blocked/prompting**: this is expected; review `offlineMarkdownViewer.externalLinks.confirm` and use explicit link opens.
 
 ## Changelog

--- a/docs/custom-css/README.md
+++ b/docs/custom-css/README.md
@@ -1,23 +1,36 @@
-# Custom CSS Setup
+# Preview Styling Setup
 
-This guide shows how to style Offline Markdown Preview with your own CSS.
+This guide shows how to style Offline Markdown Preview with installed GitHub styling or your own CSS.
 
-You can either set the paths directly in settings JSON or run **Offline Markdown Preview: Set Custom CSS** from the Command Palette and pick the file interactively.
+You can either toggle the built-in GitHub styling import, set the paths directly in settings JSON, or run **Offline Markdown Preview: Set Custom CSS** from the Command Palette and choose the style option interactively.
 
 The extension supports two layers:
 
+- `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling`: import CSS from the installed `bierner.markdown-preview-github-styles` extension.
 - `offlineMarkdownViewer.preview.globalCustomCssPath`: a user-level stylesheet applied to every preview.
 - `offlineMarkdownViewer.preview.customCssPath`: a workspace- or folder-level stylesheet applied after the global stylesheet.
 
-If both are configured, workspace CSS wins on conflicts because it is injected second.
+If all three are configured, the installed GitHub styling is injected first, then global CSS, then workspace CSS. Workspace CSS wins on conflicts because it is injected last.
 
 For a repo-local test file you can use immediately, this repository includes `docs/custom-css/test-preview.css`.
 
 ## When To Use Each Setting
 
-Use the global setting when you want one consistent look everywhere, such as a GitHub-like Markdown theme.
+Use the installed GitHub styling setting when you already have **Markdown Preview Github Styling** installed and want to reuse its CSS directly, including its own `colorTheme`, `lightTheme`, and `darkTheme` settings.
+
+Use the global setting when you want one consistent look everywhere, including when you want to layer your own tweaks on top of the imported GitHub theme.
 
 Use the workspace setting when a specific repo needs extra tweaks, such as wider tables, different code block colors, or custom typography.
+
+If you would like Offline Markdown Preview to support another Markdown styling extension directly, open an issue with the extension name and a link to it so compatibility can be evaluated.
+
+## Installed GitHub Styling Setup
+
+1. Install **Markdown Preview Github Styling** (`bierner.markdown-preview-github-styles`).
+2. Enable `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` in user settings.
+3. Reopen the preview or update the setting while the preview is open.
+
+You can also run **Offline Markdown Preview: Set Custom CSS** and choose **Use Installed GitHub Markdown Styling**.
 
 ## Global CSS Setup
 
@@ -63,12 +76,19 @@ Notes:
 
 ## GitHub-Style Setup
 
-To get close to GitHub Markdown styling:
+To get close to GitHub Markdown styling with the least setup:
 
-1. Download or create a GitHub-like Markdown stylesheet.
-2. Save it as a local file such as `/Users/you/.config/offline-markdown-preview/github-markdown.css`.
-3. Point `offlineMarkdownViewer.preview.globalCustomCssPath` to that file.
-4. Reopen the preview or update the setting while the preview is open.
+1. Install **Markdown Preview Github Styling**.
+2. Enable `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling`.
+3. Reopen the preview or update the setting while the preview is open.
+
+If you want to tweak that imported theme:
+
+1. Create a CSS file somewhere on your machine.
+2. Point `offlineMarkdownViewer.preview.globalCustomCssPath` to that file.
+3. Add only your overrides there.
+
+If you prefer not to install the GitHub styling extension, you can still save a GitHub-like stylesheet as a local file and point `offlineMarkdownViewer.preview.globalCustomCssPath` to it.
 
 You can then add a workspace override if a repo needs small adjustments.
 
@@ -117,10 +137,12 @@ body {
 
 If your styles do not apply:
 
+- Confirm `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` is enabled if you want to import CSS from the installed GitHub styling extension.
+- Confirm `bierner.markdown-preview-github-styles` is installed if the GitHub styling import is enabled.
 - Confirm the path is valid and points to a real `.css` file; non-`.css` files are ignored.
 - Use an absolute path for `offlineMarkdownViewer.preview.globalCustomCssPath`. This is a user-level opt-in for loading a stylesheet from anywhere on your machine.
 - Use a workspace- or folder-relative path for `offlineMarkdownViewer.preview.customCssPath`.
 - Make sure the workspace or folder path does not leave the workspace root.
-- Check whether a workspace or folder stylesheet is overriding the global one, because repo-local CSS is injected after the global stylesheet and wins on conflicts.
+- Check whether a workspace or folder stylesheet is overriding the imported GitHub styling or global stylesheet, because repo-local CSS is injected last and wins on conflicts.
 
 If the path is invalid or unreadable, the extension shows a warning and continues rendering the preview without that stylesheet.

--- a/package.json
+++ b/package.json
@@ -167,6 +167,12 @@
           "default": false,
           "description": "Allow loading remote http(s) images in preview. Disabled by default for offline/privacy safety."
         },
+        "offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling": {
+          "type": "boolean",
+          "scope": "machine",
+          "default": false,
+          "description": "Load CSS from the installed bierner.markdown-preview-github-styles extension before any configured custom preview CSS."
+        },
         "offlineMarkdownViewer.export.embedImages": {
           "type": "boolean",
           "default": false,
@@ -183,13 +189,13 @@
           "type": "string",
           "scope": "machine",
           "default": "",
-          "description": "Absolute path to a user-level .css file appended to every preview."
+          "description": "Absolute path to a user-level .css file appended after OMV base CSS and any imported GitHub preview styling."
         },
         "offlineMarkdownViewer.preview.customCssPath": {
           "type": "string",
           "scope": "resource",
           "default": "",
-          "description": "Workspace-relative CSS file path to append to the preview (workspace/folder settings only)."
+          "description": "Workspace-relative CSS file path to append last in the preview style order (workspace/folder settings only)."
         },
         "offlineMarkdownViewer.preview.showFrontmatter": {
           "type": "boolean",

--- a/src/extension/messaging/protocol.ts
+++ b/src/extension/messaging/protocol.ts
@@ -12,12 +12,38 @@ export interface FrontmatterInfo {
   data: Record<string, unknown>;
 }
 
+export interface GitHubMarkdownStylePayload {
+  enabled: boolean;
+  colorMode: 'auto' | 'system' | 'light' | 'dark';
+  lightTheme:
+    | 'light'
+    | 'light_high_contrast'
+    | 'light_colorblind'
+    | 'light_tritanopia'
+    | 'dark'
+    | 'dark_high_contrast'
+    | 'dark_colorblind'
+    | 'dark_tritanopia'
+    | 'dark_dimmed';
+  darkTheme:
+    | 'light'
+    | 'light_high_contrast'
+    | 'light_colorblind'
+    | 'light_tritanopia'
+    | 'dark'
+    | 'dark_high_contrast'
+    | 'dark_colorblind'
+    | 'dark_tritanopia'
+    | 'dark_dimmed';
+}
+
 export interface PreviewSettingsPayload {
   enableMermaid: boolean;
   enableMath: boolean;
   scrollSync: boolean;
   sanitizeHtml: boolean;
   showFrontmatter: boolean;
+  githubMarkdownStyle: GitHubMarkdownStylePayload;
 }
 
 export interface RenderPayload {
@@ -129,6 +155,7 @@ export interface HtmlExportSnapshotMessage {
   type: 'htmlExportSnapshot';
   requestId: number;
   html: string;
+  themeVariables?: Record<string, string>;
 }
 
 export type WebviewToExtensionMessage =

--- a/src/extension/messaging/validate.ts
+++ b/src/extension/messaging/validate.ts
@@ -9,14 +9,24 @@ const numberPercent = z.number().min(0).max(1);
 
 const webviewSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('ready') }),
-  z.object({ type: z.literal('previewScroll'), percent: numberPercent, line: z.number().int().min(0).optional() }),
+  z.object({
+    type: z.literal('previewScroll'),
+    percent: numberPercent,
+    line: z.number().int().min(0).optional()
+  }),
   z.object({
     type: z.literal('openLink'),
     href: z.string().min(1),
     kindHint: z.enum(['heading', 'external', 'relative', 'unknown']).optional()
   }),
-  z.object({ type: z.literal('headingSelected'), headingId: z.string().min(1) }),
-  z.object({ type: z.literal('copyHeadingLink'), headingId: z.string().min(1) }),
+  z.object({
+    type: z.literal('headingSelected'),
+    headingId: z.string().min(1)
+  }),
+  z.object({
+    type: z.literal('copyHeadingLink'),
+    headingId: z.string().min(1)
+  }),
   z.object({
     type: z.literal('search'),
     action: z.enum(['query', 'next', 'prev', 'clear']),
@@ -33,7 +43,8 @@ const webviewSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('htmlExportSnapshot'),
     requestId: z.number().int().nonnegative(),
-    html: z.string()
+    html: z.string(),
+    themeVariables: z.record(z.string()).optional()
   })
 ]);
 
@@ -61,7 +72,33 @@ const extSchema = z.discriminatedUnion('type', [
       enableMath: z.boolean(),
       scrollSync: z.boolean(),
       sanitizeHtml: z.boolean(),
-      showFrontmatter: z.boolean()
+      showFrontmatter: z.boolean(),
+      githubMarkdownStyle: z.object({
+        enabled: z.boolean(),
+        colorMode: z.enum(['auto', 'system', 'light', 'dark']),
+        lightTheme: z.enum([
+          'light',
+          'light_high_contrast',
+          'light_colorblind',
+          'light_tritanopia',
+          'dark',
+          'dark_high_contrast',
+          'dark_colorblind',
+          'dark_tritanopia',
+          'dark_dimmed'
+        ]),
+        darkTheme: z.enum([
+          'light',
+          'light_high_contrast',
+          'light_colorblind',
+          'light_tritanopia',
+          'dark',
+          'dark_high_contrast',
+          'dark_colorblind',
+          'dark_tritanopia',
+          'dark_dimmed'
+        ])
+      })
     })
   }),
   z.object({
@@ -70,8 +107,15 @@ const extSchema = z.discriminatedUnion('type', [
     line: z.number().int().min(0).optional(),
     source: z.literal('extension')
   }),
-  z.object({ type: z.literal('notify'), level: z.enum(['info', 'warning', 'error']), message: z.string() }),
-  z.object({ type: z.literal('searchCommand'), action: z.enum(['open', 'next', 'prev', 'clear']) }),
+  z.object({
+    type: z.literal('notify'),
+    level: z.enum(['info', 'warning', 'error']),
+    message: z.string()
+  }),
+  z.object({
+    type: z.literal('searchCommand'),
+    action: z.enum(['open', 'next', 'prev', 'clear'])
+  }),
   z.object({ type: z.literal('exportPdf') }),
   z.object({
     type: z.literal('requestHtmlExportSnapshot'),
@@ -87,6 +131,8 @@ export function parseWebviewMessage(value: unknown): WebviewToExtensionMessage {
   return webviewSchema.parse(value) as WebviewToExtensionMessage;
 }
 
-export function parseExtensionMessage(value: unknown): ExtensionToWebviewMessage {
+export function parseExtensionMessage(
+  value: unknown
+): ExtensionToWebviewMessage {
   return extSchema.parse(value) as ExtensionToWebviewMessage;
 }

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -23,6 +23,7 @@ import {
   confirmSanitizeDisabled,
   createNonce,
   getConfiguredCustomCssUris,
+  getGithubMarkdownStyleSettings,
   getWorkspaceCustomCssBaseUri,
   inlineCssTag,
   resolveCustomCss
@@ -31,6 +32,11 @@ import {
 interface PreviewPanelState {
   snapshot?: RenderedDocumentSnapshot;
   toc: TocItem[];
+}
+
+interface HtmlExportSnapshotData {
+  html: string;
+  themeVariables?: Record<string, string>;
 }
 
 interface RuntimeSettings {
@@ -45,15 +51,20 @@ interface RuntimeSettings {
   maxImageMB: number;
   embedImages: boolean;
   debounceMs: number;
+  useMarkdownPreviewGithubStyling: boolean;
 }
 
 interface CustomCssCommandChoice {
   label: string;
   description: string;
-  settingKey: 'preview.globalCustomCssPath' | 'preview.customCssPath';
+  settingKey:
+    | 'preview.globalCustomCssPath'
+    | 'preview.customCssPath'
+    | 'preview.useMarkdownPreviewGithubStyling';
   target: vscode.ConfigurationTarget;
   workspaceFolder?: vscode.WorkspaceFolder;
   clear?: boolean;
+  value?: boolean;
 }
 
 function getSettings(resource?: vscode.Uri): RuntimeSettings {
@@ -72,7 +83,11 @@ function getSettings(resource?: vscode.Uri): RuntimeSettings {
     externalConfirm: cfg.get<boolean>('externalLinks.confirm', true),
     maxImageMB: cfg.get<number>('preview.maxImageMB', 8),
     embedImages: cfg.get<boolean>('export.embedImages', false),
-    debounceMs: cfg.get<number>('performance.debounceMs', 120)
+    debounceMs: cfg.get<number>('performance.debounceMs', 120),
+    useMarkdownPreviewGithubStyling: cfg.get<boolean>(
+      'preview.useMarkdownPreviewGithubStyling',
+      false
+    )
   };
 }
 
@@ -100,6 +115,25 @@ function isUriWithinFolder(
     relative === '' ||
     (!relative.startsWith('..') && !path.isAbsolute(relative))
   );
+}
+
+function getExportThemeBodyClass(): string {
+  switch (vscode.window.activeColorTheme.kind) {
+    case vscode.ColorThemeKind.Light:
+      return 'vscode-body vscode-light';
+    case vscode.ColorThemeKind.HighContrastLight:
+      return 'vscode-body vscode-light vscode-high-contrast';
+    case vscode.ColorThemeKind.HighContrast:
+      return 'vscode-body vscode-dark vscode-high-contrast';
+    case vscode.ColorThemeKind.Dark:
+    default:
+      return 'vscode-body vscode-dark';
+  }
+}
+
+function buildGitHubMarkdownStyleAttributes(enabled: boolean): string {
+  const githubStyle = getGithubMarkdownStyleSettings(enabled);
+  return ` data-color-mode="${githubStyle.colorMode}" data-light-theme="${githubStyle.lightTheme}" data-dark-theme="${githubStyle.darkTheme}"`;
 }
 
 export class MarkdownOutlineProvider
@@ -164,7 +198,7 @@ export class PreviewController implements vscode.Disposable {
   private pendingHtmlExportSnapshot:
     | {
         requestId: number;
-        resolve: (html: string | undefined) => void;
+        resolve: (snapshot: HtmlExportSnapshotData | undefined) => void;
         timer: NodeJS.Timeout;
       }
     | undefined;
@@ -286,12 +320,19 @@ export class PreviewController implements vscode.Disposable {
         });
       }),
       vscode.workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration('offlineMarkdownViewer')) {
+        if (
+          e.affectsConfiguration('offlineMarkdownViewer') ||
+          e.affectsConfiguration('markdown-preview-github-styles')
+        ) {
           if (
             this.currentEditor &&
+            e.affectsConfiguration('offlineMarkdownViewer') &&
             (e.affectsConfiguration(
               'offlineMarkdownViewer.preview.globalCustomCssPath'
             ) ||
+              e.affectsConfiguration(
+                'offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling'
+              ) ||
               e.affectsConfiguration(
                 'offlineMarkdownViewer.preview.customCssPath',
                 this.currentEditor.document.uri
@@ -429,8 +470,8 @@ export class PreviewController implements vscode.Disposable {
     if (!snapshot) return;
 
     const settings = getSettings(snapshot.uri);
-    let html =
-      (await this.requestRenderedHtmlExportSnapshot()) ?? snapshot.html;
+    const renderedSnapshot = await this.requestRenderedHtmlExportSnapshot();
+    let html = renderedSnapshot?.html ?? snapshot.html;
     html = this.rewriteLocalImageSourcesForExport(html);
     if (settings.embedImages) {
       const answer = await vscode.window.showWarningMessage(
@@ -455,7 +496,8 @@ export class PreviewController implements vscode.Disposable {
     const document = await this.buildStandaloneHtml(
       html,
       snapshot.uri,
-      settings
+      settings,
+      renderedSnapshot?.themeVariables
     );
     await vscode.workspace.fs.writeFile(target, Buffer.from(document, 'utf8'));
     void vscode.window.showInformationMessage(
@@ -475,8 +517,8 @@ export class PreviewController implements vscode.Disposable {
     if (!snapshot) return;
 
     const settings = getSettings(snapshot.uri);
-    let html =
-      (await this.requestRenderedHtmlExportSnapshot()) ?? snapshot.html;
+    const renderedSnapshot = await this.requestRenderedHtmlExportSnapshot();
+    let html = renderedSnapshot?.html ?? snapshot.html;
     html = this.rewriteLocalImageSourcesForExport(html);
 
     if (settings.embedImages) {
@@ -502,7 +544,8 @@ export class PreviewController implements vscode.Disposable {
     const document = await this.buildStandaloneHtml(
       html,
       snapshot.uri,
-      settings
+      settings,
+      renderedSnapshot?.themeVariables
     );
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'omv-pdf-'));
     const tempHtmlPath = path.join(
@@ -568,6 +611,22 @@ export class PreviewController implements vscode.Disposable {
 
     const choices: CustomCssCommandChoice[] = [
       {
+        label: 'Use Installed GitHub Markdown Styling',
+        description:
+          'Load CSS from bierner.markdown-preview-github-styles when it is installed',
+        settingKey: 'preview.useMarkdownPreviewGithubStyling',
+        target: vscode.ConfigurationTarget.Global,
+        value: true
+      },
+      {
+        label: 'Disable Installed GitHub Markdown Styling',
+        description:
+          'Use only OMV base CSS and any configured custom stylesheets',
+        settingKey: 'preview.useMarkdownPreviewGithubStyling',
+        target: vscode.ConfigurationTarget.Global,
+        value: false
+      },
+      {
         label: 'Set Global Custom CSS',
         description: 'Choose a user-level .css file applied to every preview',
         settingKey: 'preview.globalCustomCssPath',
@@ -611,8 +670,7 @@ export class PreviewController implements vscode.Disposable {
       });
       choices.push({
         label: 'Clear Folder Custom CSS',
-        description:
-          `Remove the folder-level stylesheet for ${workspaceFolder.name}`,
+        description: `Remove the folder-level stylesheet for ${workspaceFolder.name}`,
         settingKey: 'preview.customCssPath',
         target: vscode.ConfigurationTarget.WorkspaceFolder,
         workspaceFolder,
@@ -621,7 +679,7 @@ export class PreviewController implements vscode.Disposable {
     }
 
     const picked = await vscode.window.showQuickPick(choices, {
-      placeHolder: 'Choose which custom CSS setting to configure'
+      placeHolder: 'Choose which preview style setting to configure'
     });
     if (!picked) return;
 
@@ -631,6 +689,19 @@ export class PreviewController implements vscode.Disposable {
     ) {
       void vscode.window.showInformationMessage(
         'Open a Markdown file inside a workspace folder to configure folder custom CSS.'
+      );
+      return;
+    }
+
+    if (
+      picked.settingKey === 'preview.useMarkdownPreviewGithubStyling' &&
+      typeof picked.value === 'boolean'
+    ) {
+      await cfg.update(picked.settingKey, picked.value, picked.target);
+      void vscode.window.showInformationMessage(
+        picked.value
+          ? 'Installed GitHub Markdown styling enabled.'
+          : 'Installed GitHub Markdown styling disabled.'
       );
       return;
     }
@@ -650,7 +721,7 @@ export class PreviewController implements vscode.Disposable {
     const defaultWorkspaceUri =
       picked.target === vscode.ConfigurationTarget.Workspace
         ? workspaceCustomCssBaseUri
-        : picked.workspaceFolder?.uri ?? workspaceFolder?.uri ?? resource;
+        : (picked.workspaceFolder?.uri ?? workspaceFolder?.uri ?? resource);
     const defaultUri =
       picked.settingKey === 'preview.globalCustomCssPath'
         ? resource
@@ -1014,7 +1085,10 @@ export class PreviewController implements vscode.Disposable {
         enableMath: settings.enableMath,
         scrollSync: settings.scrollSync,
         sanitizeHtml: settings.sanitizeHtml,
-        showFrontmatter: settings.showFrontmatter
+        showFrontmatter: settings.showFrontmatter,
+        githubMarkdownStyle: getGithubMarkdownStyleSettings(
+          settings.useMarkdownPreviewGithubStyling
+        )
       }
     });
   }
@@ -1123,7 +1197,10 @@ export class PreviewController implements vscode.Disposable {
           this.pendingHtmlExportSnapshot.requestId === message.requestId
         ) {
           clearTimeout(this.pendingHtmlExportSnapshot.timer);
-          this.pendingHtmlExportSnapshot.resolve(message.html);
+          this.pendingHtmlExportSnapshot.resolve({
+            html: message.html,
+            themeVariables: message.themeVariables
+          });
           this.pendingHtmlExportSnapshot = undefined;
         }
         break;
@@ -1283,7 +1360,7 @@ export class PreviewController implements vscode.Disposable {
   }
 
   private async requestRenderedHtmlExportSnapshot(): Promise<
-    string | undefined
+    HtmlExportSnapshotData | undefined
   > {
     if (!this.panel) return undefined;
 
@@ -1294,7 +1371,7 @@ export class PreviewController implements vscode.Disposable {
     }
 
     const requestId = ++this.htmlExportSnapshotReqId;
-    return new Promise<string | undefined>((resolve) => {
+    return new Promise<HtmlExportSnapshotData | undefined>((resolve) => {
       const timer = setTimeout(() => {
         if (this.pendingHtmlExportSnapshot?.requestId === requestId) {
           this.pendingHtmlExportSnapshot.resolve(undefined);
@@ -1707,7 +1784,8 @@ export class PreviewController implements vscode.Disposable {
   private async buildStandaloneHtml(
     bodyHtml: string,
     sourceUri: vscode.Uri,
-    settings: RuntimeSettings
+    settings: RuntimeSettings,
+    themeVariables?: Record<string, string>
   ): Promise<string> {
     const cssPath = vscode.Uri.joinPath(
       this.context.extensionUri,
@@ -1737,6 +1815,18 @@ export class PreviewController implements vscode.Disposable {
       settings.showFrontmatter && this.state.snapshot?.frontmatter
         ? `<details open><summary>Frontmatter</summary><pre>${escapeHtml(this.state.snapshot.frontmatter.raw)}</pre></details>`
         : '';
+    const githubStyleAttributes = buildGitHubMarkdownStyleAttributes(
+      settings.useMarkdownPreviewGithubStyling
+    );
+    const themeStyleAttribute = buildInlineStyleAttribute(themeVariables);
+    const wrappedBodyHtml = `<article class="omv-preview">
+${frontmatter}
+<div class="omv-content markdown-body github-markdown-body"${githubStyleAttributes}${themeStyleAttribute}>
+<div class="github-markdown-content">
+${bodyHtml}
+</div>
+</div>
+</article>`;
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -1747,9 +1837,8 @@ export class PreviewController implements vscode.Disposable {
 <style>${baseCss}</style>
 ${customCssTags}
 </head>
-<body>
-${frontmatter}
-${bodyHtml}
+<body class="${getExportThemeBodyClass()}">
+${wrappedBodyHtml}
 </body>
 </html>`;
   }
@@ -1774,6 +1863,21 @@ function escapeHtml(value: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+function buildInlineStyleAttribute(
+  styleMap: Record<string, string> | undefined
+): string {
+  if (!styleMap) {
+    return '';
+  }
+
+  const declarations = Object.entries(styleMap)
+    .filter(([, value]) => value.trim().length > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => `${name}: ${value};`)
+    .join(' ');
+  return declarations ? ` style="${escapeHtml(declarations)}"` : '';
 }
 
 function isDisposedWebviewError(error: unknown): boolean {

--- a/src/extension/preview/markdown/security.ts
+++ b/src/extension/preview/markdown/security.ts
@@ -3,6 +3,8 @@ import { createHash, randomBytes } from 'node:crypto';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
+import type { GitHubMarkdownStylePayload } from '../../messaging/protocol';
+
 export interface ResolvedCustomCss {
   cssTexts: string[];
   key: string;
@@ -16,7 +18,33 @@ interface CustomCssConfig {
   workspaceScope?: CustomCssScope;
   workspaceBaseUri?: vscode.Uri;
   workspaceFolder?: vscode.WorkspaceFolder;
+  useMarkdownPreviewGithubStyling: boolean;
 }
+
+interface ContributedMarkdownStyleExtension {
+  extensionUri: vscode.Uri;
+  packageJSON?: {
+    contributes?: {
+      'markdown.previewStyles'?: unknown;
+    };
+  };
+}
+
+const githubThemeModes = ['auto', 'system', 'light', 'dark'] as const;
+const githubThemeNames = [
+  'light',
+  'light_high_contrast',
+  'light_colorblind',
+  'light_tritanopia',
+  'dark',
+  'dark_high_contrast',
+  'dark_colorblind',
+  'dark_tritanopia',
+  'dark_dimmed'
+] as const;
+
+type GitHubThemeMode = (typeof githubThemeModes)[number];
+type GitHubThemeName = (typeof githubThemeNames)[number];
 
 export function createNonce(): string {
   return randomBytes(16).toString('hex');
@@ -92,9 +120,7 @@ function getCustomCssConfig(documentUri: vscode.Uri): CustomCssConfig {
   const customCssInspect = cfg.inspect<string>('preview.customCssPath');
   const rawWorkspaceFolderPath = customCssInspect?.workspaceFolderValue;
   const rawWorkspacePath = customCssInspect?.workspaceValue;
-  const workspaceFolderPath = normalizeConfiguredPath(
-    rawWorkspaceFolderPath
-  );
+  const workspaceFolderPath = normalizeConfiguredPath(rawWorkspaceFolderPath);
   const workspacePath = normalizeConfiguredPath(rawWorkspacePath);
   const hasWorkspaceFolderOverride = rawWorkspaceFolderPath !== undefined;
 
@@ -115,13 +141,18 @@ function getCustomCssConfig(documentUri: vscode.Uri): CustomCssConfig {
       : workspacePath
         ? getWorkspaceCustomCssBaseUri()
         : undefined,
-    workspaceFolder
+    workspaceFolder,
+    useMarkdownPreviewGithubStyling: cfg.get<boolean>(
+      'preview.useMarkdownPreviewGithubStyling',
+      false
+    )
   };
 }
 
 function buildCustomCssKey(config: CustomCssConfig): string {
   return JSON.stringify({
     globalPath: config.globalPath ?? '',
+    useMarkdownPreviewGithubStyling: config.useMarkdownPreviewGithubStyling,
     workspaceBase: config.workspaceBaseUri?.fsPath ?? '',
     workspaceFolder: config.workspaceFolder?.uri.fsPath ?? '',
     workspaceScope: config.workspaceScope ?? '',
@@ -140,7 +171,120 @@ function getOpenDocumentText(uri: vscode.Uri): string | undefined {
   return openDocument?.getText();
 }
 
-function getGlobalCustomCssUri(globalPath: string | undefined): vscode.Uri | undefined {
+function isGithubThemeMode(value: unknown): value is GitHubThemeMode {
+  return githubThemeModes.includes(value as GitHubThemeMode);
+}
+
+function isGithubThemeName(value: unknown): value is GitHubThemeName {
+  return githubThemeNames.includes(value as GitHubThemeName);
+}
+
+export function getGithubMarkdownStyleSettings(
+  enabled: boolean
+): GitHubMarkdownStylePayload {
+  const settings = vscode.workspace.getConfiguration(
+    'markdown-preview-github-styles',
+    null
+  );
+  const colorModeSetting = settings.get<string>('colorTheme');
+  const lightThemeSetting = settings.get<string>('lightTheme');
+  const darkThemeSetting = settings.get<string>('darkTheme');
+
+  return {
+    enabled,
+    colorMode: isGithubThemeMode(colorModeSetting) ? colorModeSetting : 'auto',
+    lightTheme: isGithubThemeName(lightThemeSetting)
+      ? lightThemeSetting
+      : 'light',
+    darkTheme: isGithubThemeName(darkThemeSetting) ? darkThemeSetting : 'dark'
+  };
+}
+
+function getGithubMarkdownStyleExtension():
+  | ContributedMarkdownStyleExtension
+  | undefined {
+  const extension = vscode.extensions.getExtension<
+    ContributedMarkdownStyleExtension['packageJSON']
+  >('bierner.markdown-preview-github-styles');
+  if (!extension) {
+    return undefined;
+  }
+
+  return extension as unknown as ContributedMarkdownStyleExtension;
+}
+
+function getGithubMarkdownStyleUris(): vscode.Uri[] {
+  const extension = getGithubMarkdownStyleExtension();
+  if (!extension) {
+    return [];
+  }
+
+  const previewStyles =
+    extension.packageJSON?.contributes?.['markdown.previewStyles'];
+  if (!Array.isArray(previewStyles)) {
+    return [];
+  }
+
+  const uris: vscode.Uri[] = [];
+  for (const stylePath of previewStyles) {
+    if (typeof stylePath !== 'string' || !stylePath.trim()) {
+      continue;
+    }
+
+    const target = vscode.Uri.joinPath(extension.extensionUri, stylePath);
+    if (path.extname(target.fsPath).toLowerCase() !== '.css') {
+      continue;
+    }
+
+    uris.push(target);
+  }
+
+  return uris;
+}
+
+async function readGithubMarkdownPreviewStyles(
+  enabled: boolean
+): Promise<string[]> {
+  if (!enabled) {
+    return [];
+  }
+
+  const extension = getGithubMarkdownStyleExtension();
+  if (!extension) {
+    void vscode.window.showWarningMessage(
+      'GitHub Markdown styling is enabled, but bierner.markdown-preview-github-styles is not installed.'
+    );
+    return [];
+  }
+
+  const cssTexts: string[] = [];
+  let hadReadError = false;
+  for (const target of getGithubMarkdownStyleUris()) {
+    const openDocumentText = getOpenDocumentText(target);
+    if (openDocumentText !== undefined) {
+      cssTexts.push(openDocumentText);
+      continue;
+    }
+
+    try {
+      cssTexts.push(await fs.readFile(target.fsPath, 'utf8'));
+    } catch {
+      hadReadError = true;
+    }
+  }
+
+  if (hadReadError) {
+    void vscode.window.showWarningMessage(
+      'Could not read one or more CSS files from bierner.markdown-preview-github-styles.'
+    );
+  }
+
+  return cssTexts;
+}
+
+function getGlobalCustomCssUri(
+  globalPath: string | undefined
+): vscode.Uri | undefined {
   if (
     !globalPath ||
     !path.isAbsolute(globalPath) ||
@@ -151,9 +295,7 @@ function getGlobalCustomCssUri(globalPath: string | undefined): vscode.Uri | und
   return vscode.Uri.file(globalPath);
 }
 
-function getWorkspaceCustomCssUris(
-  config: CustomCssConfig
-): vscode.Uri[] {
+function getWorkspaceCustomCssUris(config: CustomCssConfig): vscode.Uri[] {
   if (!config.workspacePath || !config.workspaceScope) {
     return [];
   }
@@ -280,8 +422,19 @@ export async function resolveCustomCss(
 ): Promise<ResolvedCustomCss> {
   const config = getCustomCssConfig(documentUri);
   const cssTexts: string[] = [];
+  let githubStyleHash = '';
   let globalHash = '';
   let workspaceHash = '';
+
+  if (config.useMarkdownPreviewGithubStyling) {
+    const githubCssTexts = await readGithubMarkdownPreviewStyles(
+      config.useMarkdownPreviewGithubStyling
+    );
+    if (githubCssTexts.length > 0) {
+      cssTexts.push(...githubCssTexts);
+      githubStyleHash = githubCssTexts.map(hashCssText).join(':');
+    }
+  }
 
   if (config.globalPath) {
     const globalCss = await readGlobalCustomCss(config.globalPath);
@@ -303,6 +456,7 @@ export async function resolveCustomCss(
     cssTexts,
     key: JSON.stringify({
       config: buildCustomCssKey(config),
+      githubStyleHash,
       globalHash,
       workspaceHash
     })

--- a/src/webview-ui/app/renderer.ts
+++ b/src/webview-ui/app/renderer.ts
@@ -9,10 +9,17 @@ import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-css';
 import 'prismjs/components/prism-bash';
 
-import type { RenderPayload, TocItem } from '../../extension/messaging/protocol';
+import type {
+  RenderPayload,
+  TocItem
+} from '../../extension/messaging/protocol';
+import { getEffectiveMermaidThemeKind } from './themeUtils';
 
 export interface RendererBridge {
-  onOpenLink(href: string, kindHint?: 'heading' | 'external' | 'relative' | 'unknown'): void;
+  onOpenLink(
+    href: string,
+    kindHint?: 'heading' | 'external' | 'relative' | 'unknown'
+  ): void;
   onHeadingSelect(id: string): void;
   onCopyHeadingLink(id: string): void;
   onOpenImage(src: string): void;
@@ -32,12 +39,16 @@ export class PreviewRenderer {
   private toc: TocItem[] = [];
   private activeHeadingId: string | undefined;
   private readonly content: HTMLElement;
+  private readonly styledRoot: HTMLElement;
   private readonly frontmatter: HTMLDetailsElement;
   private readonly banner: HTMLElement;
   private mermaidInitialized = false;
   private mermaidThemeSignature = '';
 
-  constructor(private readonly host: HTMLElement, private readonly bridge: RendererBridge) {
+  constructor(
+    private readonly host: HTMLElement,
+    private readonly bridge: RendererBridge
+  ) {
     this.banner = document.createElement('div');
     this.banner.className = 'omv-status-banner';
     this.banner.hidden = true;
@@ -46,10 +57,16 @@ export class PreviewRenderer {
     this.frontmatter.className = 'omv-frontmatter';
     this.frontmatter.hidden = true;
 
-    this.content = document.createElement('div');
-    this.content.className = 'omv-content';
+    this.styledRoot = document.createElement('div');
+    this.styledRoot.className =
+      'omv-content markdown-body github-markdown-body';
 
-    this.host.append(this.banner, this.frontmatter, this.content);
+    this.content = document.createElement('div');
+    this.content.className = 'github-markdown-content';
+
+    this.styledRoot.append(this.content);
+
+    this.host.append(this.banner, this.frontmatter, this.styledRoot);
     this.host.addEventListener('click', (event) => this.handleClick(event));
   }
 
@@ -65,8 +82,13 @@ export class PreviewRenderer {
     return this.activeHeadingId;
   }
 
+  getComputedThemeVariables(): Record<string, string> {
+    return collectThemeVariables(this.styledRoot);
+  }
+
   async render(payload: RenderPayload): Promise<void> {
     this.toc = payload.toc;
+    this.applyGitHubMarkdownStyle(payload.settings);
     this.renderFrontmatter(payload);
     const tableAlignments = extractTableAlignments(payload.html);
 
@@ -92,6 +114,7 @@ export class PreviewRenderer {
       : payload.html;
 
     this.content.innerHTML = String(sanitized);
+    applyContentTheme(this.styledRoot);
     applyTableAlignments(this.content, tableAlignments);
     this.decorateHeadings();
     this.decorateImageActions();
@@ -106,6 +129,24 @@ export class PreviewRenderer {
 
   setActiveHeading(id?: string): void {
     this.activeHeadingId = id;
+  }
+
+  async refreshTheme(settings: RenderPayload['settings']): Promise<void> {
+    this.applyGitHubMarkdownStyle(settings);
+    applyContentTheme(this.styledRoot);
+    await this.enhanceMermaid(settings.enableMermaid);
+  }
+
+  private applyGitHubMarkdownStyle(settings: RenderPayload['settings']): void {
+    const githubStyle = settings.githubMarkdownStyle;
+    this.host.classList.toggle(
+      'omv-uses-github-markdown-style',
+      githubStyle.enabled
+    );
+
+    this.styledRoot.dataset.colorMode = githubStyle.colorMode;
+    this.styledRoot.dataset.lightTheme = githubStyle.lightTheme;
+    this.styledRoot.dataset.darkTheme = githubStyle.darkTheme;
   }
 
   private renderFrontmatter(payload: RenderPayload): void {
@@ -130,11 +171,13 @@ export class PreviewRenderer {
       return;
     }
     this.banner.hidden = false;
-    this.banner.textContent = 'Warning: HTML sanitization is disabled for this preview.';
+    this.banner.textContent =
+      'Warning: HTML sanitization is disabled for this preview.';
   }
 
   private decorateHeadings(): void {
-    const headings = this.content.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6');
+    const headings =
+      this.content.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6');
     for (const heading of headings) {
       const id = heading.id;
       if (!id) continue;
@@ -153,7 +196,9 @@ export class PreviewRenderer {
   }
 
   private decorateImageActions(): void {
-    const imgs = this.content.querySelectorAll<HTMLImageElement>('img[data-local-src]');
+    const imgs = this.content.querySelectorAll<HTMLImageElement>(
+      'img[data-local-src]'
+    );
     for (const img of imgs) {
       img.addEventListener('click', () => {
         const localSrc = img.getAttribute('data-local-src');
@@ -161,7 +206,9 @@ export class PreviewRenderer {
       });
     }
 
-    const remoteImgs = this.content.querySelectorAll<HTMLImageElement>('img[data-remote-src]');
+    const remoteImgs = this.content.querySelectorAll<HTMLImageElement>(
+      'img[data-remote-src]'
+    );
     for (const img of remoteImgs) {
       const src = img.getAttribute('data-remote-src');
       if (!src) continue;
@@ -184,7 +231,9 @@ export class PreviewRenderer {
   }
 
   private async enhanceMath(enableMath: boolean): Promise<void> {
-    const nodes = [...this.content.querySelectorAll<HTMLElement>('[data-math]')];
+    const nodes = [
+      ...this.content.querySelectorAll<HTMLElement>('[data-math]')
+    ];
     if (!enableMath) {
       for (const node of nodes) {
         const expr = decodeBase64(node.dataset.math ?? '');
@@ -215,7 +264,11 @@ export class PreviewRenderer {
   }
 
   private async enhanceMermaid(enableMermaid: boolean): Promise<void> {
-    const nodes = [...this.content.querySelectorAll<HTMLElement>('.omv-mermaid[data-mermaid]')];
+    const nodes = [
+      ...this.content.querySelectorAll<HTMLElement>(
+        '.omv-mermaid[data-mermaid]'
+      )
+    ];
     if (!enableMermaid) {
       for (const node of nodes) {
         node.textContent = decodeBase64(node.dataset.mermaid ?? '');
@@ -223,8 +276,11 @@ export class PreviewRenderer {
       return;
     }
 
-    const mermaidTheme = buildMermaidThemeConfig();
-    if (!this.mermaidInitialized || this.mermaidThemeSignature !== mermaidTheme.signature) {
+    const mermaidTheme = buildMermaidThemeConfig(this.styledRoot);
+    if (
+      !this.mermaidInitialized ||
+      this.mermaidThemeSignature !== mermaidTheme.signature
+    ) {
       try {
         mermaid.initialize({
           startOnLoad: false,
@@ -291,14 +347,28 @@ export class PreviewRenderer {
         const recovery = buildMermaidRecoveryAttempt(code, diagramType);
         if (recovery) {
           try {
-            const recovered = await mermaid.render(`${id}-recovery`, recovery.code);
+            const recovered = await mermaid.render(
+              `${id}-recovery`,
+              recovery.code
+            );
             node.setAttribute('data-omv-mermaid-recovered', 'true');
-            node.setAttribute('data-omv-mermaid-recovery-strategy', recovery.strategy);
-            node.replaceChildren(buildMermaidSvgNode(recovered.svg, diagramType));
+            node.setAttribute(
+              'data-omv-mermaid-recovery-strategy',
+              recovery.strategy
+            );
+            node.replaceChildren(
+              buildMermaidSvgNode(recovered.svg, diagramType)
+            );
             continue;
           } catch (recoveryError) {
-            const hints = buildMermaidErrorHints(code, diagramType, recoveryError);
-            node.replaceChildren(buildMermaidErrorNode(code, recoveryError, hints));
+            const hints = buildMermaidErrorHints(
+              code,
+              diagramType,
+              recoveryError
+            );
+            node.replaceChildren(
+              buildMermaidErrorNode(code, recoveryError, hints)
+            );
             continue;
           }
         }
@@ -317,7 +387,9 @@ export class PreviewRenderer {
     const target = event.target as HTMLElement | null;
     if (!target) return;
 
-    const remoteDownload = target.closest<HTMLButtonElement>('button[data-remote-image-src]');
+    const remoteDownload = target.closest<HTMLButtonElement>(
+      'button[data-remote-image-src]'
+    );
     if (remoteDownload) {
       event.preventDefault();
       const src = remoteDownload.dataset.remoteImageSrc;
@@ -346,20 +418,56 @@ export class PreviewRenderer {
   }
 }
 
-function buildMermaidThemeConfig(): {
+function buildMermaidThemeConfig(themeRoot: HTMLElement): {
   signature: string;
   themeVariables: Record<string, string | number | boolean>;
 } {
   const bodyStyle = getComputedStyle(document.body);
-  const bodyFontSize = Number.parseFloat(bodyStyle.fontSize || '14');
-  const themeKind = document.body.dataset.vscodeThemeKind ?? 'light';
+  const rootStyle = getComputedStyle(themeRoot);
+  const probe = createThemeProbe(themeRoot);
+  const linkStyle = getComputedStyle(probe.link);
+  const preStyle = getComputedStyle(probe.pre);
+  const blockquoteStyle = getComputedStyle(probe.blockquote);
 
-  const fg = bodyStyle.color || 'rgb(204, 204, 204)';
-  const bg = bodyStyle.backgroundColor || 'rgb(30, 30, 30)';
-  const border = resolveThemeColor('var(--omv-border)', 'borderTopColor', 'rgba(127,127,127,0.35)');
-  const accent = resolveThemeColor('var(--omv-accent)', 'color', fg);
-  const codeBg = resolveThemeColor('var(--omv-code-bg)', 'backgroundColor', bg);
-  const editorBg = resolveThemeColor('var(--vscode-editor-background)', 'backgroundColor', bg);
+  const bodyFontSize = Number.parseFloat(bodyStyle.fontSize || '14');
+
+  const fg = firstDefinedColor(
+    rootStyle.color,
+    bodyStyle.color,
+    'rgb(204, 204, 204)'
+  );
+  const bg = firstOpaqueColor(
+    rootStyle.backgroundColor,
+    bodyStyle.backgroundColor,
+    'rgb(30, 30, 30)'
+  );
+  const border = firstOpaqueColor(
+    blockquoteStyle.borderLeftColor,
+    preStyle.borderTopColor,
+    resolveThemeColor(
+      'var(--omv-border)',
+      'borderTopColor',
+      'rgba(127,127,127,0.35)'
+    ),
+    fg
+  );
+  const accent = firstDefinedColor(
+    linkStyle.color,
+    resolveThemeColor('var(--omv-accent)', 'color', fg),
+    fg
+  );
+  const codeBg = firstOpaqueColor(
+    preStyle.backgroundColor,
+    resolveThemeColor('var(--omv-code-bg)', 'backgroundColor', bg),
+    bg
+  );
+  const editorBg = bg;
+  const themeKind = getEffectiveMermaidThemeKind(
+    bg,
+    document.body.dataset.vscodeThemeKind ?? 'light'
+  );
+
+  probe.root.remove();
 
   // High-contrast should prefer stronger edge/node borders.
   const strongBorder = themeKind === 'high-contrast' ? fg : border;
@@ -494,16 +602,265 @@ function getMermaidCategoricalPalette(themeKind: string): string[] {
   ];
 }
 
+function createThemeProbe(themeRoot: HTMLElement): {
+  root: HTMLDivElement;
+  content: HTMLDivElement;
+  link: HTMLAnchorElement;
+  code: HTMLElement;
+  pre: HTMLPreElement;
+  blockquote: HTMLQuoteElement;
+} {
+  const root = document.createElement('div');
+  root.setAttribute('aria-hidden', 'true');
+  root.style.position = 'absolute';
+  root.style.left = '-99999px';
+  root.style.top = '0';
+  root.style.visibility = 'hidden';
+  root.style.pointerEvents = 'none';
+  // Mirror the live styled root so the probe picks up OMV base rules as well as
+  // any imported GitHub markdown selectors.
+  root.className = themeRoot.className;
+  root.dataset.colorMode = themeRoot.dataset.colorMode ?? 'auto';
+  root.dataset.lightTheme = themeRoot.dataset.lightTheme ?? 'light';
+  root.dataset.darkTheme = themeRoot.dataset.darkTheme ?? 'dark';
+
+  const content = document.createElement('div');
+  content.className = 'github-markdown-content';
+
+  const link = document.createElement('a');
+  link.href = '#';
+  link.textContent = 'link';
+
+  const code = document.createElement('code');
+  code.textContent = 'const value = 1;';
+
+  const pre = document.createElement('pre');
+  pre.textContent = 'code';
+
+  const blockquote = document.createElement('blockquote');
+  blockquote.textContent = 'quote';
+
+  content.append(link, code, pre, blockquote);
+  root.append(content);
+  (themeRoot.parentElement ?? themeRoot).append(root);
+  return { root, content, link, code, pre, blockquote };
+}
+
+const computedThemeVarNames = [
+  '--omv-mermaid-panel-bg',
+  '--omv-mermaid-viewport-bg',
+  '--omv-mermaid-border',
+  '--omv-mermaid-muted',
+  '--omv-mermaid-accent',
+  '--omv-active-pre-fg',
+  '--omv-active-pre-bg',
+  '--omv-active-pre-border',
+  '--omv-active-pre-radius',
+  '--omv-active-inline-code-fg',
+  '--omv-active-inline-code-bg',
+  '--omv-active-inline-code-radius',
+  '--omv-code-fg',
+  '--omv-code-bg',
+  '--omv-syntax-comment',
+  '--omv-syntax-keyword',
+  '--omv-syntax-string',
+  '--omv-syntax-function',
+  '--omv-syntax-class',
+  '--omv-syntax-number',
+  '--omv-syntax-constant',
+  '--omv-syntax-property',
+  '--omv-syntax-tag',
+  '--omv-syntax-attr-name',
+  '--omv-syntax-operator',
+  '--omv-syntax-punctuation',
+  '--omv-syntax-inserted',
+  '--omv-syntax-deleted'
+] as const;
+
+function resetComputedThemeVars(themeRoot: HTMLElement): void {
+  for (const name of computedThemeVarNames) {
+    themeRoot.style.removeProperty(name);
+  }
+}
+
+function applyContentTheme(themeRoot: HTMLElement): void {
+  resetComputedThemeVars(themeRoot);
+
+  const probe = createThemeProbe(themeRoot);
+  const rootStyle = getComputedStyle(themeRoot);
+  const linkStyle = getComputedStyle(probe.link);
+  const codeStyle = getComputedStyle(probe.code);
+  const preStyle = getComputedStyle(probe.pre);
+  const blockquoteStyle = getComputedStyle(probe.blockquote);
+
+  const panelBg = firstOpaqueColor(
+    preStyle.backgroundColor,
+    rootStyle.backgroundColor,
+    'rgba(0, 0, 0, 0)'
+  );
+  const viewportBg = firstOpaqueColor(
+    rootStyle.backgroundColor,
+    panelBg,
+    'rgba(0, 0, 0, 0)'
+  );
+  const border = firstOpaqueColor(
+    preStyle.borderTopColor,
+    blockquoteStyle.borderLeftColor,
+    'rgba(127,127,127,0.35)'
+  );
+  const muted = firstDefinedColor(
+    blockquoteStyle.color,
+    rootStyle.color,
+    'inherit'
+  );
+  const accent = firstDefinedColor(linkStyle.color, rootStyle.color, 'inherit');
+
+  themeRoot.style.setProperty('--omv-mermaid-panel-bg', panelBg);
+  themeRoot.style.setProperty('--omv-mermaid-viewport-bg', viewportBg);
+  themeRoot.style.setProperty('--omv-mermaid-border', border);
+  themeRoot.style.setProperty('--omv-mermaid-muted', muted);
+  themeRoot.style.setProperty('--omv-mermaid-accent', accent);
+
+  applyCodeTheme(themeRoot, {
+    rootStyle,
+    codeStyle,
+    preStyle
+  });
+
+  probe.root.remove();
+}
+
+function collectThemeVariables(themeRoot: HTMLElement): Record<string, string> {
+  const variables: Record<string, string> = {};
+  for (const name of computedThemeVarNames) {
+    const value = themeRoot.style.getPropertyValue(name).trim();
+    if (value) {
+      variables[name] = value;
+    }
+  }
+  return variables;
+}
+
+function applyCodeTheme(
+  themeRoot: HTMLElement,
+  styles: {
+    rootStyle: CSSStyleDeclaration;
+    codeStyle: CSSStyleDeclaration;
+    preStyle: CSSStyleDeclaration;
+  }
+): void {
+  const preFg = firstDefinedColor(
+    styles.preStyle.color,
+    styles.rootStyle.color,
+    'inherit'
+  );
+  const preBg = firstOpaqueColor(
+    styles.preStyle.backgroundColor,
+    'rgba(0, 0, 0, 0)'
+  );
+  const preBorder = firstOpaqueColor(
+    styles.preStyle.borderTopColor,
+    'rgba(0, 0, 0, 0)'
+  );
+  const inlineFg = firstDefinedColor(
+    styles.codeStyle.color,
+    styles.rootStyle.color,
+    'inherit'
+  );
+  const inlineBg = firstOpaqueColor(
+    styles.codeStyle.backgroundColor,
+    preBg,
+    'rgba(0, 0, 0, 0)'
+  );
+
+  themeRoot.style.setProperty('--omv-active-pre-fg', preFg);
+  themeRoot.style.setProperty('--omv-active-pre-bg', preBg);
+  themeRoot.style.setProperty('--omv-active-pre-border', preBorder);
+  themeRoot.style.setProperty(
+    '--omv-active-pre-radius',
+    styles.preStyle.borderRadius || '8px'
+  );
+  themeRoot.style.setProperty('--omv-active-inline-code-fg', inlineFg);
+  themeRoot.style.setProperty('--omv-active-inline-code-bg', inlineBg);
+  themeRoot.style.setProperty(
+    '--omv-active-inline-code-radius',
+    styles.codeStyle.borderRadius || '4px'
+  );
+  themeRoot.style.setProperty('--omv-code-fg', preFg);
+  themeRoot.style.setProperty('--omv-code-bg', preBg);
+
+  const syntaxVarMap = {
+    '--omv-syntax-comment': '--color-prettylights-syntax-comment',
+    '--omv-syntax-keyword': '--color-prettylights-syntax-keyword',
+    '--omv-syntax-string': '--color-prettylights-syntax-string',
+    '--omv-syntax-function': '--color-prettylights-syntax-entity',
+    '--omv-syntax-class': '--color-prettylights-syntax-entity',
+    '--omv-syntax-number': '--color-prettylights-syntax-constant',
+    '--omv-syntax-constant': '--color-prettylights-syntax-variable',
+    '--omv-syntax-property': '--color-prettylights-syntax-constant',
+    '--omv-syntax-tag': '--color-prettylights-syntax-entity-tag',
+    '--omv-syntax-attr-name': '--color-prettylights-syntax-constant',
+    '--omv-syntax-operator': '--fgColor-default',
+    '--omv-syntax-punctuation': '--fgColor-muted',
+    '--omv-syntax-inserted': '--color-prettylights-syntax-markup-inserted-text',
+    '--omv-syntax-deleted': '--color-prettylights-syntax-markup-deleted-text'
+  } as const;
+
+  for (const [targetVar, sourceVar] of Object.entries(syntaxVarMap)) {
+    const value = styles.rootStyle.getPropertyValue(sourceVar).trim();
+    if (value) {
+      themeRoot.style.setProperty(targetVar, value);
+    } else {
+      themeRoot.style.removeProperty(targetVar);
+    }
+  }
+}
+
+function isTransparentColor(value: string | undefined | null): boolean {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase();
+  return (
+    !normalized ||
+    normalized === 'transparent' ||
+    normalized === 'rgba(0, 0, 0, 0)' ||
+    normalized === 'rgba(0,0,0,0)'
+  );
+}
+
+function firstOpaqueColor(...values: string[]): string {
+  for (const value of values) {
+    if (!isTransparentColor(value)) {
+      return value;
+    }
+  }
+  return values[values.length - 1] ?? 'rgb(30, 30, 30)';
+}
+
+function firstDefinedColor(...values: string[]): string {
+  for (const value of values) {
+    if (String(value ?? '').trim()) {
+      return value;
+    }
+  }
+  return values[values.length - 1] ?? 'rgb(204, 204, 204)';
+}
+
 function getReadableTextColorForHex(hex: string): string {
   const rgb = parseHexColor(hex);
   if (!rgb) return '#111111';
   const [r, g, b] = rgb.map((v) => v / 255);
-  const linear = [r, g, b].map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
-  const luminance = 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+  const linear = [r, g, b].map((c) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  );
+  const luminance =
+    0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
   return luminance > 0.45 ? '#111111' : '#f5f7fa';
 }
 
-function parseHexColor(hex: string | undefined | null): [number, number, number] | undefined {
+function parseHexColor(
+  hex: string | undefined | null
+): [number, number, number] | undefined {
   const value = String(hex ?? '')
     .trim()
     .replace(/^#/, '');
@@ -537,7 +894,10 @@ function buildMermaidSvgNode(svgMarkup: string, diagramType?: string): Node {
   if (svg) {
     // Mermaid often emits inline sizing styles. Normalize sizing to the preview container.
     svg.removeAttribute('style');
-    const hasValidViewBox = svg.viewBox.baseVal && svg.viewBox.baseVal.width > 0 && svg.viewBox.baseVal.height > 0;
+    const hasValidViewBox =
+      svg.viewBox.baseVal &&
+      svg.viewBox.baseVal.width > 0 &&
+      svg.viewBox.baseVal.height > 0;
     if (hasValidViewBox) {
       const viewBox = svg.viewBox.baseVal;
       const widthAttr = svg.getAttribute('width') ?? '';
@@ -572,14 +932,19 @@ function buildMermaidSvgNode(svgMarkup: string, diagramType?: string): Node {
   return wrapper.firstElementChild ?? document.createTextNode(svgMarkup);
 }
 
-function styleMermaidEdgeLabelBackgrounds(svg: SVGSVGElement, diagramType?: string): void {
+function styleMermaidEdgeLabelBackgrounds(
+  svg: SVGSVGElement,
+  diagramType?: string
+): void {
   // This visual patch is intended for flowchart edge labels like |sanitizeHtml=true|.
   // Applying it to sequence/class labels distorts callout/message bubbles.
   if (diagramType && !/^(flowchart|graph)$/i.test(diagramType)) {
     return;
   }
   // Keep edge-label text/layout untouched. Only enhance the background rect so labels don't clip.
-  for (const rect of svg.querySelectorAll<SVGRectElement>('g.edgeLabel rect.labelBkg')) {
+  for (const rect of svg.querySelectorAll<SVGRectElement>(
+    'g.edgeLabel rect.labelBkg'
+  )) {
     const x = Number.parseFloat(rect.getAttribute('x') ?? '');
     const y = Number.parseFloat(rect.getAttribute('y') ?? '');
     const width = Number.parseFloat(rect.getAttribute('width') ?? '');
@@ -605,7 +970,9 @@ function styleMermaidEdgeLabelBackgrounds(svg: SVGSVGElement, diagramType?: stri
 function normalizePieLegendColors(svg: SVGSVGElement): void {
   // Mermaid pie slices use SVG attrs, but legend swatches are often emitted via inline style()
   // and can lose color under strict sanitization. Reapply legend colors from slice fills.
-  const sliceFills = Array.from(svg.querySelectorAll<SVGPathElement>('path.pieCircle'))
+  const sliceFills = Array.from(
+    svg.querySelectorAll<SVGPathElement>('path.pieCircle')
+  )
     .map((path) => path.getAttribute('fill') || path.style.fill || '')
     .filter((value) => value.trim().length > 0);
   if (sliceFills.length === 0) return;
@@ -621,7 +988,11 @@ function normalizePieLegendColors(svg: SVGSVGElement): void {
   });
 }
 
-function buildMermaidErrorNode(code: string, error: unknown, hints: string[] = []): HTMLElement {
+function buildMermaidErrorNode(
+  code: string,
+  error: unknown,
+  hints: string[] = []
+): HTMLElement {
   const root = document.createElement('div');
   root.className = 'omv-mermaid-error';
 
@@ -687,12 +1058,18 @@ function detectMermaidDiagramType(code: string | undefined | null): string {
   return match?.[1] ?? 'unknown';
 }
 
-function buildMermaidRecoveryAttempt(code: string, diagramType: string): MermaidRecoveryAttempt | undefined {
+function buildMermaidRecoveryAttempt(
+  code: string,
+  diagramType: string
+): MermaidRecoveryAttempt | undefined {
   const normalizedType = diagramType.trim().toLowerCase();
   if (/^requirement(diagram)?$/i.test(normalizedType)) {
     const normalized = normalizeRequirementDiagramSyntax(code);
     if (normalized !== code) {
-      return { code: normalized, strategy: 'requirement-diagram-normalization' };
+      return {
+        code: normalized,
+        strategy: 'requirement-diagram-normalization'
+      };
     }
     return undefined;
   }
@@ -740,14 +1117,20 @@ function normalizeBlockBetaNodeLabels(code: string): string {
   return lines.join('\n');
 }
 
-function buildMermaidErrorHints(code: string, diagramType: string, error: unknown): string[] {
+function buildMermaidErrorHints(
+  code: string,
+  diagramType: string,
+  error: unknown
+): string[] {
   const hints: string[] = [];
   const normalizedType = diagramType.trim().toLowerCase();
   const message = getErrorMessage(error);
 
   if (/^(flowchart|graph)$/i.test(normalizedType)) {
     if (/\[[^\n]*\[\][^\n]*\]/u.test(code)) {
-      hints.push('Flowchart labels with raw [] often fail inside A[...]. Use quoted labels: A["..."].');
+      hints.push(
+        'Flowchart labels with raw [] often fail inside A[...]. Use quoted labels: A["..."].'
+      );
     }
   }
 
@@ -759,21 +1142,29 @@ function buildMermaidErrorHints(code: string, diagramType: string, error: unknow
       hints.push('Use `docRef` (camelCase), not `docref`.');
     }
     if (/^\s*id\s*:\s*[^"\n]*-[^"\n]*$/mu.test(code)) {
-      hints.push('Use alphanumeric requirement IDs (for example `REQ1`) instead of `REQ-1`.');
+      hints.push(
+        'Use alphanumeric requirement IDs (for example `REQ1`) instead of `REQ-1`.'
+      );
     }
     if (/^\s*text\s*:\s*[^"\n]+\s+[^"\n]+$/mu.test(code)) {
-      hints.push('Quote multi-word `text:` values, e.g. `text: "render markdown offline"`.');
+      hints.push(
+        'Quote multi-word `text:` values, e.g. `text: "render markdown offline"`.'
+      );
     }
   }
 
   if (normalizedType === 'block-beta') {
     if (/^[ \t]*[A-Za-z_][\w-]*\[[^\]]+\]/mu.test(code)) {
-      hints.push('`block-beta` does not use flowchart node syntax like `A[Label]`; use `A|Label|` or plain `A`.');
+      hints.push(
+        '`block-beta` does not use flowchart node syntax like `A[Label]`; use `A|Label|` or plain `A`.'
+      );
     }
   }
 
   if (hints.length === 0 && /syntax error/i.test(message)) {
-    hints.push('This parser error is generic. Validate the snippet with Mermaid 11.12.x syntax rules.');
+    hints.push(
+      'This parser error is generic. Validate the snippet with Mermaid 11.12.x syntax rules.'
+    );
   }
 
   return Array.from(new Set(hints));
@@ -805,7 +1196,10 @@ function createMermaidInteractiveViewer(svg: SVGSVGElement): HTMLElement {
   viewport.className = 'omv-mermaid-viewport';
   viewport.tabIndex = 0;
   viewport.setAttribute('role', 'group');
-  viewport.setAttribute('aria-label', 'Mermaid diagram viewer. Drag to pan. Ctrl or Cmd + wheel to zoom.');
+  viewport.setAttribute(
+    'aria-label',
+    'Mermaid diagram viewer. Drag to pan. Ctrl or Cmd + wheel to zoom.'
+  );
 
   const canvas = document.createElement('div');
   canvas.className = 'omv-mermaid-canvas';
@@ -981,7 +1375,12 @@ function normalizeSvgViewBoxFromContent(svg: SVGSVGElement): void {
   }
   try {
     const bbox = svg.getBBox();
-    if (!Number.isFinite(bbox.width) || !Number.isFinite(bbox.height) || bbox.width <= 0 || bbox.height <= 0) {
+    if (
+      !Number.isFinite(bbox.width) ||
+      !Number.isFinite(bbox.height) ||
+      bbox.width <= 0 ||
+      bbox.height <= 0
+    ) {
       return;
     }
     const pad = 8;
@@ -1004,7 +1403,11 @@ function normalizeSvgViewBoxFromContent(svg: SVGSVGElement): void {
   }
 }
 
-function button(label: string, title: string, onClick: () => void): HTMLButtonElement {
+function button(
+  label: string,
+  title: string,
+  onClick: () => void
+): HTMLButtonElement {
   const el = document.createElement('button');
   el.type = 'button';
   el.className = 'omv-mermaid-btn';
@@ -1014,7 +1417,10 @@ function button(label: string, title: string, onClick: () => void): HTMLButtonEl
   return el;
 }
 
-function getSvgNaturalSize(svg: SVGSVGElement): { width: number; height: number } {
+function getSvgNaturalSize(svg: SVGSVGElement): {
+  width: number;
+  height: number;
+} {
   const viewBox = svg.viewBox.baseVal;
   if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
     return { width: viewBox.width, height: viewBox.height };
@@ -1062,7 +1468,8 @@ function clampPan(
 }
 
 function getBootStyleNonce(): string | undefined {
-  const boot = (window as Window & { __OMV_BOOT__?: { styleNonce?: string } }).__OMV_BOOT__;
+  const boot = (window as Window & { __OMV_BOOT__?: { styleNonce?: string } })
+    .__OMV_BOOT__;
   return boot?.styleNonce;
 }
 
@@ -1078,7 +1485,10 @@ function resolveThemeColor(
   probe.style.overflow = 'hidden';
   probe.style.pointerEvents = 'none';
   probe.style.opacity = '0';
-  probe.style.setProperty(property === 'borderTopColor' ? 'border-top-color' : property, token);
+  probe.style.setProperty(
+    property === 'borderTopColor' ? 'border-top-color' : property,
+    token
+  );
   if (property === 'borderTopColor') {
     probe.style.borderTopStyle = 'solid';
     probe.style.borderTopWidth = '1px';
@@ -1092,7 +1502,9 @@ function resolveThemeColor(
         ? computed.backgroundColor
         : computed.color;
   probe.remove();
-  return resolved && !/^rgba?\(0,\s*0,\s*0(?:,\s*0)?\)$/i.test(resolved) ? resolved : fallback;
+  return resolved && !/^rgba?\(0,\s*0,\s*0(?:,\s*0)?\)$/i.test(resolved)
+    ? resolved
+    : fallback;
 }
 
 function decodeBase64(value: string): string {
@@ -1110,7 +1522,9 @@ function decodeBase64(value: string): string {
 function nextTick(): Promise<void> {
   return new Promise((resolve) => {
     if ('requestIdleCallback' in window) {
-      (window as Window & { requestIdleCallback: (cb: () => void) => number }).requestIdleCallback(() => resolve());
+      (
+        window as Window & { requestIdleCallback: (cb: () => void) => number }
+      ).requestIdleCallback(() => resolve());
       return;
     }
     setTimeout(resolve, 0);
@@ -1124,21 +1538,31 @@ function extractTableAlignments(rawHtml: string): TableAlignment[] {
   return Array.from(doc.querySelectorAll('table')).map((table) => {
     const row = table.querySelector('tr');
     if (!row) return [];
-    return Array.from(row.children).map((cell) => readAlignment(cell as HTMLElement));
+    return Array.from(row.children).map((cell) =>
+      readAlignment(cell as HTMLElement)
+    );
   });
 }
 
-function readAlignment(cell: HTMLElement): 'left' | 'center' | 'right' | undefined {
-  const alignAttr = cell.getAttribute('data-align') || cell.getAttribute('align');
+function readAlignment(
+  cell: HTMLElement
+): 'left' | 'center' | 'right' | undefined {
+  const alignAttr =
+    cell.getAttribute('data-align') || cell.getAttribute('align');
   if (alignAttr && /^(left|center|right)$/i.test(alignAttr)) {
     return alignAttr.toLowerCase() as 'left' | 'center' | 'right';
   }
   const style = cell.getAttribute('style') ?? '';
   const match = /text-align\s*:\s*(left|center|right)/i.exec(style);
-  return match ? (match[1].toLowerCase() as 'left' | 'center' | 'right') : undefined;
+  return match
+    ? (match[1].toLowerCase() as 'left' | 'center' | 'right')
+    : undefined;
 }
 
-function applyTableAlignments(root: HTMLElement, tableAlignments: TableAlignment[]): void {
+function applyTableAlignments(
+  root: HTMLElement,
+  tableAlignments: TableAlignment[]
+): void {
   const tables = root.querySelectorAll<HTMLTableElement>('table');
   tables.forEach((table, tableIndex) => {
     const aligns = tableAlignments[tableIndex] ?? [];
@@ -1148,7 +1572,11 @@ function applyTableAlignments(root: HTMLElement, tableAlignments: TableAlignment
       Array.from(row.children).forEach((cell, colIndex) => {
         const align = aligns[colIndex];
         if (!align) return;
-        cell.classList.remove('omv-align-left', 'omv-align-center', 'omv-align-right');
+        cell.classList.remove(
+          'omv-align-left',
+          'omv-align-center',
+          'omv-align-right'
+        );
         cell.classList.add(`omv-align-${align}`);
         (cell as HTMLElement).style.textAlign = align;
       });

--- a/src/webview-ui/app/theme.ts
+++ b/src/webview-ui/app/theme.ts
@@ -1,15 +1,28 @@
-export function initTheme(): void {
+import {
+  getThemeKindFromBodyClass,
+  normalizeObservedBodyClass,
+  shouldRefreshTheme
+} from './themeUtils';
+
+export function initTheme(onChange?: () => void): void {
+  let previousBodyClass: string | undefined;
+
   const apply = () => {
     const body = document.body;
-    const cls = body.className;
-    body.dataset.vscodeThemeKind = cls.includes('vscode-high-contrast')
-      ? 'high-contrast'
-      : cls.includes('vscode-dark')
-        ? 'dark'
-        : 'light';
+    const nextBodyClass = normalizeObservedBodyClass(body.className);
+    body.className = nextBodyClass;
+    const nextThemeKind = getThemeKindFromBodyClass(nextBodyClass);
+    body.dataset.vscodeThemeKind = nextThemeKind;
+    if (shouldRefreshTheme(previousBodyClass, nextBodyClass)) {
+      onChange?.();
+    }
+    previousBodyClass = nextBodyClass;
   };
 
   apply();
   const observer = new MutationObserver(apply);
-  observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ['class']
+  });
 }

--- a/src/webview-ui/app/themeUtils.ts
+++ b/src/webview-ui/app/themeUtils.ts
@@ -1,0 +1,117 @@
+export type PreviewThemeKind = 'light' | 'dark' | 'high-contrast';
+
+export function getThemeKindFromBodyClass(
+  className: string
+): PreviewThemeKind {
+  if (className.includes('vscode-high-contrast')) {
+    return 'high-contrast';
+  }
+  if (className.includes('vscode-dark')) {
+    return 'dark';
+  }
+  return 'light';
+}
+
+export function normalizeObservedBodyClass(className: string): string {
+  const classNames = new Set(
+    className
+      .split(/\s+/u)
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+
+  const hasHighContrastLight = [...classNames].some(
+    (value) =>
+      value === 'vscode-high-contrast-light' ||
+      value.includes('vscode-high-contrast-light')
+  );
+  const hasHighContrast = [...classNames].some(
+    (value) =>
+      value === 'vscode-high-contrast' ||
+      value.includes('vscode-high-contrast')
+  );
+
+  classNames.add('vscode-body');
+  if (hasHighContrastLight) {
+    classNames.add('vscode-high-contrast');
+    classNames.add('vscode-light');
+  } else if (hasHighContrast) {
+    classNames.add('vscode-dark');
+  }
+  return [...classNames].sort().join(' ');
+}
+
+export function shouldRefreshTheme(
+  previousBodyClass: string | undefined,
+  nextBodyClass: string
+): boolean {
+  return Boolean(previousBodyClass && previousBodyClass !== nextBodyClass);
+}
+
+export function getEffectiveMermaidThemeKind(
+  backgroundColor: string,
+  fallbackThemeKind: PreviewThemeKind
+): PreviewThemeKind {
+  if (fallbackThemeKind === 'high-contrast') {
+    return 'high-contrast';
+  }
+  return isDarkColor(backgroundColor) ? 'dark' : 'light';
+}
+
+function isDarkColor(value: string): boolean {
+  const rgb = parseCssColor(value);
+  if (!rgb) {
+    return false;
+  }
+
+  const [r, g, b] = rgb.map((channel) => channel / 255);
+  const linear = [r, g, b].map((channel) =>
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  );
+  const luminance =
+    0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+  return luminance < 0.45;
+}
+
+function parseCssColor(value: string): [number, number, number] | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const rgbMatch = normalized.match(
+    /^rgba?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)(?:\s*,\s*[\d.]+\s*)?\)$/
+  );
+  if (rgbMatch) {
+    return [
+      Number.parseFloat(rgbMatch[1]),
+      Number.parseFloat(rgbMatch[2]),
+      Number.parseFloat(rgbMatch[3])
+    ];
+  }
+
+  return parseHexColor(normalized);
+}
+
+function parseHexColor(
+  hex: string | undefined | null
+): [number, number, number] | undefined {
+  const value = String(hex ?? '')
+    .trim()
+    .replace(/^#/, '');
+  if (!/^[\da-fA-F]{3}([\da-fA-F]{3})?$/.test(value)) {
+    return undefined;
+  }
+
+  const full =
+    value.length === 3
+      ? value
+          .split('')
+          .map((ch) => ch + ch)
+          .join('')
+      : value;
+  const r = Number.parseInt(full.slice(0, 2), 16);
+  const g = Number.parseInt(full.slice(2, 4), 16);
+  const b = Number.parseInt(full.slice(4, 6), 16);
+  return [r, g, b];
+}

--- a/src/webview-ui/assets/styles.css
+++ b/src/webview-ui/assets/styles.css
@@ -1,7 +1,10 @@
 :root {
   --omv-bg: var(--vscode-editor-background);
   --omv-fg: var(--vscode-editor-foreground);
-  --omv-muted: var(--vscode-descriptionForeground, color-mix(in srgb, var(--omv-fg) 60%, transparent));
+  --omv-muted: var(
+    --vscode-descriptionForeground,
+    color-mix(in srgb, var(--omv-fg) 60%, transparent)
+  );
   --omv-border: var(--vscode-panel-border, rgba(127, 127, 127, 0.25));
   --omv-accent: var(--vscode-textLink-foreground, #0f6cbd);
   --omv-accent-weak: color-mix(in srgb, var(--omv-accent) 18%, transparent);
@@ -9,7 +12,10 @@
     --vscode-textCodeBlock-background,
     color-mix(in srgb, var(--omv-bg) 86%, var(--omv-fg) 14%)
   );
-  --omv-code-fg: var(--vscode-textPreformat-foreground, var(--vscode-editor-foreground, var(--omv-fg)));
+  --omv-code-fg: var(
+    --vscode-textPreformat-foreground,
+    var(--vscode-editor-foreground, var(--omv-fg))
+  );
   --omv-mark-bg: color-mix(in srgb, #ffdb4d 55%, var(--omv-bg));
   --omv-sidebar-width: 260px;
   /* Prism in a webview cannot read the active VS Code theme's token colors directly.
@@ -25,9 +31,19 @@
   --omv-syntax-tag: #569cd6;
   --omv-syntax-attr-name: #9cdcfe;
   --omv-syntax-operator: var(--omv-code-fg);
-  --omv-syntax-punctuation: color-mix(in srgb, var(--omv-code-fg) 78%, transparent);
-  --omv-syntax-inserted: var(--vscode-gitDecoration-addedResourceForeground, #6a9955);
-  --omv-syntax-deleted: var(--vscode-gitDecoration-deletedResourceForeground, #f44747);
+  --omv-syntax-punctuation: color-mix(
+    in srgb,
+    var(--omv-code-fg) 78%,
+    transparent
+  );
+  --omv-syntax-inserted: var(
+    --vscode-gitDecoration-addedResourceForeground,
+    #6a9955
+  );
+  --omv-syntax-deleted: var(
+    --vscode-gitDecoration-deletedResourceForeground,
+    #f44747
+  );
 }
 
 body[data-vscode-theme-kind='light'] {
@@ -87,8 +103,11 @@ input {
   gap: 0.5rem;
   padding: 0.35rem 0.75rem;
   border-bottom: 1px solid var(--omv-border);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--omv-bg) 90%, var(--omv-fg) 10%), var(--omv-bg));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--omv-bg) 90%, var(--omv-fg) 10%),
+    var(--omv-bg)
+  );
 }
 
 .omv-chrome-actions {
@@ -133,8 +152,11 @@ input {
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   border-bottom: 1px solid var(--omv-border);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--omv-bg) 92%, var(--omv-fg) 8%), var(--omv-bg));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--omv-bg) 92%, var(--omv-fg) 8%),
+    var(--omv-bg)
+  );
 }
 
 .omv-toolbar[hidden] {
@@ -331,24 +353,31 @@ input {
   cursor: default;
 }
 
-.omv-content pre {
+:where(.omv-content) pre {
   padding: 0.8rem;
   overflow: auto;
-  border-radius: 8px;
-  background: var(--omv-code-bg);
-  border: 1px solid var(--omv-border);
+  border-radius: var(--omv-active-pre-radius, 8px);
+  background: var(--omv-active-pre-bg, var(--omv-code-bg));
+  color: var(--omv-active-pre-fg, var(--omv-code-fg));
+  border: 1px solid var(--omv-active-pre-border, var(--omv-border));
 }
 
-.omv-content code {
-  font-family: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, monospace);
+:where(.omv-content) code {
+  font-family: var(
+    --vscode-editor-font-family,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
   font-size: 0.92em;
-  color: var(--omv-code-fg);
+  color: var(--omv-active-inline-code-fg, var(--omv-code-fg));
 }
 
-.omv-content :not(pre) > code {
-  background: var(--omv-code-bg);
+:where(.omv-content) :where(:not(pre) > code) {
+  background: var(--omv-active-inline-code-bg, var(--omv-code-bg));
   padding: 0.1rem 0.25rem;
-  border-radius: 4px;
+  border-radius: var(--omv-active-inline-code-radius, 4px);
 }
 
 .omv-content table {
@@ -400,9 +429,12 @@ input {
 
 .omv-content .omv-mermaid {
   padding: 0.5rem;
-  border: 1px solid var(--omv-border);
+  border: 1px solid var(--omv-mermaid-border, var(--omv-border));
   border-radius: 8px;
-  background: color-mix(in srgb, var(--omv-bg) 96%, var(--omv-fg) 4%);
+  background: var(
+    --omv-mermaid-panel-bg,
+    color-mix(in srgb, var(--omv-bg) 96%, var(--omv-fg) 4%)
+  );
   overflow: hidden;
 }
 
@@ -415,15 +447,36 @@ input {
   place-items: center;
   gap: 0.5rem;
   min-height: 140px;
-  border: 1px dashed color-mix(in srgb, var(--omv-border) 80%, transparent);
-  border-radius: 8px;
-  background:
-    linear-gradient(
-      110deg,
-      color-mix(in srgb, var(--omv-bg) 96%, var(--omv-fg) 4%) 30%,
-      color-mix(in srgb, var(--omv-bg) 90%, var(--omv-fg) 10%) 45%,
-      color-mix(in srgb, var(--omv-bg) 96%, var(--omv-fg) 4%) 60%
+  border: 1px dashed
+    color-mix(
+      in srgb,
+      var(--omv-mermaid-border, var(--omv-border)) 80%,
+      transparent
     );
+  border-radius: 8px;
+  background: linear-gradient(
+    110deg,
+    var(
+        --omv-mermaid-panel-bg,
+        color-mix(in srgb, var(--omv-bg) 96%, var(--omv-fg) 4%)
+      )
+      30%,
+    color-mix(
+        in srgb,
+        var(
+            --omv-mermaid-panel-bg,
+            color-mix(in srgb, var(--omv-bg) 96%, var(--omv-fg) 4%)
+          )
+          88%,
+        var(--omv-mermaid-border, var(--omv-fg)) 12%
+      )
+      45%,
+    var(
+        --omv-mermaid-panel-bg,
+        color-mix(in srgb, var(--omv-bg) 96%, var(--omv-fg) 4%)
+      )
+      60%
+  );
   background-size: 220% 100%;
   animation: omv-mermaid-loading-sheen 1.4s linear infinite;
 }
@@ -432,14 +485,15 @@ input {
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  border: 2px solid color-mix(in srgb, var(--omv-fg) 20%, transparent);
-  border-top-color: var(--omv-accent);
+  border: 2px solid
+    color-mix(in srgb, var(--omv-mermaid-muted, var(--omv-fg)) 20%, transparent);
+  border-top-color: var(--omv-mermaid-accent, var(--omv-accent));
   animation: omv-mermaid-loading-spin 0.9s linear infinite;
 }
 
 .omv-content .omv-mermaid-loading-label {
   font-size: 12px;
-  color: var(--omv-muted);
+  color: var(--omv-mermaid-muted, var(--omv-muted));
   text-align: center;
 }
 
@@ -457,7 +511,7 @@ input {
 }
 
 .omv-content .omv-mermaid-btn {
-  border: 1px solid var(--omv-border);
+  border: 1px solid var(--omv-mermaid-border, var(--omv-border));
   background: transparent;
   color: inherit;
   border-radius: 6px;
@@ -467,20 +521,27 @@ input {
 }
 
 .omv-content .omv-mermaid-btn:hover {
-  background: var(--omv-accent-weak);
+  background: color-mix(
+    in srgb,
+    var(--omv-mermaid-accent, var(--omv-accent)) 14%,
+    transparent
+  );
 }
 
 .omv-content .omv-mermaid-hint {
-  color: var(--omv-muted);
+  color: var(--omv-mermaid-muted, var(--omv-muted));
   font-size: 12px;
   margin-left: auto;
 }
 
 .omv-content .omv-mermaid-viewport {
   position: relative;
-  border: 1px solid var(--omv-border);
+  border: 1px solid var(--omv-mermaid-border, var(--omv-border));
   border-radius: 8px;
-  background: color-mix(in srgb, var(--omv-bg) 98%, var(--omv-fg) 2%);
+  background: var(
+    --omv-mermaid-viewport-bg,
+    color-mix(in srgb, var(--omv-bg) 98%, var(--omv-fg) 2%)
+  );
   overflow: hidden;
   cursor: grab;
   touch-action: none;
@@ -488,7 +549,12 @@ input {
 }
 
 .omv-content .omv-mermaid-viewport:focus-visible {
-  box-shadow: 0 0 0 2px var(--omv-accent-weak);
+  box-shadow: 0 0 0 2px
+    color-mix(
+      in srgb,
+      var(--omv-mermaid-accent, var(--omv-accent)) 14%,
+      transparent
+    );
 }
 
 .omv-content .omv-mermaid-viewport.is-dragging {
@@ -512,66 +578,144 @@ input {
   margin: 0;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='flowchart'] g.edgeLabel rect.labelBkg,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='graph'] g.edgeLabel rect.labelBkg,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='flowchart']
+  g.edgeLabel
+  rect.labelBkg,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='graph']
+  g.edgeLabel
+  rect.labelBkg,
 .omv-content .omv-mermaid svg rect.omv-edge-label-bkg,
 .omv-content .omv-mermaid svg rect[data-omv-edge-label-bkg='true'] {
   fill: color-mix(in srgb, var(--omv-bg) 90%, var(--omv-fg) 10%) !important;
-  stroke: color-mix(in srgb, var(--omv-accent) 28%, var(--omv-border)) !important;
+  stroke: color-mix(
+    in srgb,
+    var(--omv-accent) 28%,
+    var(--omv-border)
+  ) !important;
   stroke-width: 1 !important;
-  filter: drop-shadow(0 1px 0 color-mix(in srgb, var(--omv-bg) 55%, transparent));
+  filter: drop-shadow(
+    0 1px 0 color-mix(in srgb, var(--omv-bg) 55%, transparent)
+  );
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='flowchart'] g.edgeLabel .label,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='graph'] g.edgeLabel .label {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='flowchart']
+  g.edgeLabel
+  .label,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='graph']
+  g.edgeLabel
+  .label {
   background: transparent !important;
   border-radius: 8px;
   box-shadow: none !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='flowchart'] g.edgeLabel .label p,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='graph'] g.edgeLabel .label p {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='flowchart']
+  g.edgeLabel
+  .label
+  p,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='graph']
+  g.edgeLabel
+  .label
+  p {
   margin: 0;
   background: transparent !important;
 }
 
 /* Sequence diagram self-message/callout labels should not inherit the flowchart chip look. */
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] rect.labelBkg {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  rect.labelBkg {
   fill: transparent !important;
   stroke: none !important;
   filter: none !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] .actor-line,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] .messageLine0,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] .messageLine1 {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  .actor-line,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  .messageLine0,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  .messageLine1 {
   stroke: var(--omv-fg) !important;
   stroke-opacity: 0.95 !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] .messageLine0,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] .messageLine1,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] .innerArc {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  .messageLine0,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  .messageLine1,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  .innerArc {
   fill: none !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] #arrowhead path,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] #crosshead path {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  #arrowhead
+  path,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  #crosshead
+  path {
   fill: var(--omv-fg) !important;
   stroke: var(--omv-fg) !important;
   stroke-opacity: 0.95 !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='sequencediagram'] #sequencenumber {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='sequencediagram']
+  #sequencenumber {
   fill: color-mix(in srgb, var(--omv-bg) 92%, var(--omv-fg) 8%) !important;
   stroke: var(--omv-fg) !important;
   stroke-opacity: 0.65 !important;
 }
 
 /* ER diagram relationship labels should not inherit markdown container word-wrapping. */
-.omv-content .omv-mermaid svg[data-omv-diagram-type='erdiagram'] .edgeLabel .label,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='erdiagram'] .edgeLabel .label p,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='erdiagram'] .edgeLabel .label span {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='erdiagram']
+  .edgeLabel
+  .label,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='erdiagram']
+  .edgeLabel
+  .label
+  p,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='erdiagram']
+  .edgeLabel
+  .label
+  span {
   white-space: normal !important;
   word-break: normal !important;
   overflow-wrap: normal !important;
@@ -579,24 +723,52 @@ input {
   line-height: 1.15 !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='erdiagram'] .edgeLabel .label {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='erdiagram']
+  .edgeLabel
+  .label {
   font-size: 12px !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='erdiagram'] .edgeLabel .label p {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='erdiagram']
+  .edgeLabel
+  .label
+  p {
   margin: 0 !important;
 }
 
 /* Mindmap: prefer readable label text over Mermaid's derived palette text colors. */
-.omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .mindmap-node-label,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .mindmap-node-label tspan,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .section-root text,
-.omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .section-root tspan {
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='mindmap']
+  .mindmap-node-label,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='mindmap']
+  .mindmap-node-label
+  tspan,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='mindmap']
+  .section-root
+  text,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='mindmap']
+  .section-root
+  tspan {
   fill: #f5f7fa !important;
   stroke: none !important;
 }
 
-.omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .section-root span,
+.omv-content
+  .omv-mermaid
+  svg[data-omv-diagram-type='mindmap']
+  .section-root
+  span,
 .omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .section-0 span,
 .omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .section-1 span,
 .omv-content .omv-mermaid svg[data-omv-diagram-type='mindmap'] .section-2 span,
@@ -706,94 +878,156 @@ input {
   background: color-mix(in srgb, var(--omv-bg) 94%, var(--omv-fg) 6%);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) {
-  color: var(--omv-code-fg);
+:where(.omv-content) :is(pre[class*='language-'], code[class*='language-']) {
+  color: var(--omv-active-pre-fg, var(--omv-code-fg));
   text-shadow: none;
 }
 
-.omv-content pre[class*='language-'] code[class*='language-'] {
+:where(.omv-content) pre[class*='language-'] code[class*='language-'] {
   background: transparent;
   padding: 0;
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.comment,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.prolog,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.doctype,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.cdata {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.comment,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.prolog,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.doctype,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.cdata {
   color: var(--omv-syntax-comment);
   font-style: italic;
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.keyword,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.selector,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.important,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.atrule {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.keyword,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.selector,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.important,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.atrule {
   color: var(--omv-syntax-keyword);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.string,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.string,
 .omv-content :is(pre[class*='language-'], code[class*='language-']) .token.char,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.attr-value,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.regex,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.inserted {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.attr-value,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.regex,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.inserted {
   color: var(--omv-syntax-string);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.function {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.function {
   color: var(--omv-syntax-function);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.class-name {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.class-name {
   color: var(--omv-syntax-class);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.number,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.boolean,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.constant,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.symbol {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.number,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.boolean,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.constant,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.symbol {
   color: var(--omv-syntax-number);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.deleted {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.deleted {
   color: var(--omv-syntax-deleted);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.property,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.parameter,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.variable {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.property,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.parameter,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.variable {
   color: var(--omv-syntax-property);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.builtin,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.annotation {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.builtin,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.annotation {
   color: var(--omv-syntax-constant);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.operator,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.entity,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.operator,
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.entity,
 .omv-content :is(pre[class*='language-'], code[class*='language-']) .token.url {
   color: var(--omv-syntax-operator);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.punctuation {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.punctuation {
   color: var(--omv-syntax-punctuation);
 }
 
 .omv-content :is(pre[class*='language-'], code[class*='language-']) .token.tag,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.namespace {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.namespace {
   color: var(--omv-syntax-tag);
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.attr-name {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.attr-name {
   color: var(--omv-syntax-attr-name);
 }
 
 .omv-content :is(pre[class*='language-'], code[class*='language-']) .token.bold,
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.important {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.important {
   font-weight: 600;
 }
 
-.omv-content :is(pre[class*='language-'], code[class*='language-']) .token.italic {
+.omv-content
+  :is(pre[class*='language-'], code[class*='language-'])
+  .token.italic {
   font-style: italic;
 }
 

--- a/src/webview-ui/index.ts
+++ b/src/webview-ui/index.ts
@@ -2,7 +2,10 @@ import './assets/styles.css';
 import 'katex/dist/katex.min.css';
 import './assets/katex.min.css';
 
-import type { ExtensionToWebviewMessage, RenderPayload } from '../extension/messaging/protocol';
+import type {
+  ExtensionToWebviewMessage,
+  RenderPayload
+} from '../extension/messaging/protocol';
 import { parseExtensionMessage } from '../extension/messaging/validate';
 import { PreviewRenderer } from './app/renderer';
 import { PreviewSearch } from './app/search';
@@ -57,7 +60,9 @@ root.innerHTML = `
   </div>
 `;
 
-const searchInput = root.querySelector<HTMLInputElement>('input[type="search"]');
+const searchInput = root.querySelector<HTMLInputElement>(
+  'input[type="search"]'
+);
 const meta = root.querySelector<HTMLElement>('.omv-meta');
 const tocEl = root.querySelector<HTMLElement>('.omv-toc');
 const article = root.querySelector<HTMLElement>('.omv-preview');
@@ -65,12 +70,19 @@ const scroller = root.querySelector<HTMLElement>('.omv-preview-scroll');
 const searchToolbar = root.querySelector<HTMLElement>('#omv-search-toolbar');
 const mainLayout = root.querySelector<HTMLElement>('#omv-main');
 
-if (!searchInput || !meta || !tocEl || !article || !scroller || !searchToolbar || !mainLayout) {
+if (
+  !searchInput ||
+  !meta ||
+  !tocEl ||
+  !article ||
+  !scroller ||
+  !searchToolbar ||
+  !mainLayout
+) {
   throw new Error('Webview UI bootstrap failed');
 }
 
 const state = (vscode.getState() as ViewState | undefined) ?? {};
-initTheme();
 
 let lastRender: RenderPayload | undefined;
 let searchUiVisible = state.searchUiVisible ?? true;
@@ -98,16 +110,23 @@ const renderer = new PreviewRenderer(article, {
   }
 });
 
-const search = new PreviewSearch(renderer.getContentElement(), (count, index) => {
-  meta.textContent = count === 0 ? '' : `${index + 1}/${count}`;
-});
-
-const scrollSync = new ScrollSyncController(scroller, renderer.getContentElement(), {
-  postPreviewScroll(percent, line) {
-    if (!lastRender?.settings.scrollSync) return;
-    vscode.postMessage({ type: 'previewScroll', percent, line });
+const search = new PreviewSearch(
+  renderer.getContentElement(),
+  (count, index) => {
+    meta.textContent = count === 0 ? '' : `${index + 1}/${count}`;
   }
-});
+);
+
+const scrollSync = new ScrollSyncController(
+  scroller,
+  renderer.getContentElement(),
+  {
+    postPreviewScroll(percent, line) {
+      if (!lastRender?.settings.scrollSync) return;
+      vscode.postMessage({ type: 'previewScroll', percent, line });
+    }
+  }
+);
 
 const toc = new TocView(tocEl, (item) => {
   renderer.setActiveHeading(item.id);
@@ -115,6 +134,12 @@ const toc = new TocView(tocEl, (item) => {
   scrollSync.scrollHeadingIntoView(item.id);
   vscode.postMessage({ type: 'headingSelected', headingId: item.id });
   persistState();
+});
+
+initTheme(() => {
+  if (lastRender) {
+    void renderer.refreshTheme(lastRender.settings);
+  }
 });
 
 searchInput.value = state.searchQuery ?? '';
@@ -126,11 +151,15 @@ searchInput.addEventListener('input', () => {
   persistState();
 });
 
-for (const btn of root.querySelectorAll<HTMLButtonElement>('button[data-ui-toggle]')) {
+for (const btn of root.querySelectorAll<HTMLButtonElement>(
+  'button[data-ui-toggle]'
+)) {
   btn.addEventListener('click', () => {
     const target = btn.dataset.uiToggle;
     if (target === 'search') {
-      setSearchUiVisible(!searchUiVisible, { focus: searchUiVisible ? false : true });
+      setSearchUiVisible(!searchUiVisible, {
+        focus: searchUiVisible ? false : true
+      });
     }
     if (target === 'toc') {
       setTocVisible(!tocVisible);
@@ -139,7 +168,9 @@ for (const btn of root.querySelectorAll<HTMLButtonElement>('button[data-ui-toggl
   });
 }
 
-for (const btn of root.querySelectorAll<HTMLButtonElement>('button[data-chrome-action]')) {
+for (const btn of root.querySelectorAll<HTMLButtonElement>(
+  'button[data-chrome-action]'
+)) {
   btn.addEventListener('click', () => {
     const action = btn.dataset.chromeAction;
     if (action === 'export') {
@@ -155,7 +186,9 @@ searchInput.addEventListener('keydown', (event) => {
   }
 });
 
-for (const btn of root.querySelectorAll<HTMLButtonElement>('button[data-action]')) {
+for (const btn of root.querySelectorAll<HTMLButtonElement>(
+  'button[data-action]'
+)) {
   btn.addEventListener('click', () => {
     const action = btn.dataset.action;
     if (action === 'next') search.next();
@@ -180,7 +213,11 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
 });
 
 window.addEventListener('keydown', (event) => {
-  if ((event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === 'f') {
+  if (
+    (event.metaKey || event.ctrlKey) &&
+    !event.altKey &&
+    event.key.toLowerCase() === 'f'
+  ) {
     event.preventDefault();
     setSearchUiVisible(true, { focus: true, select: true });
     persistState();
@@ -189,10 +226,15 @@ window.addEventListener('keydown', (event) => {
 
 vscode.postMessage({ type: 'ready' });
 
-async function handleMessage(message: ExtensionToWebviewMessage): Promise<void> {
+async function handleMessage(
+  message: ExtensionToWebviewMessage
+): Promise<void> {
   switch (message.type) {
     case 'updateCustomCss': {
       applyCustomCss(message.cssTexts);
+      if (lastRender) {
+        await renderer.refreshTheme(lastRender.settings);
+      }
       break;
     }
     case 'render': {
@@ -236,15 +278,21 @@ async function handleMessage(message: ExtensionToWebviewMessage): Promise<void> 
         window.print();
         vscode.postMessage({ type: 'pdfExportResult', ok: true });
       } catch (error) {
-        vscode.postMessage({ type: 'pdfExportResult', ok: false, error: String(error) });
+        vscode.postMessage({
+          type: 'pdfExportResult',
+          ok: false,
+          error: String(error)
+        });
       }
       break;
     }
     case 'requestHtmlExportSnapshot': {
+      const snapshot = buildRenderedHtmlExportSnapshot();
       vscode.postMessage({
         type: 'htmlExportSnapshot',
         requestId: message.requestId,
-        html: buildRenderedHtmlExportSnapshot()
+        html: snapshot.html,
+        themeVariables: snapshot.themeVariables
       });
       break;
     }
@@ -313,23 +361,32 @@ function applyUiVisibility(): void {
   mainLayout.classList.toggle('omv-toc-collapsed', !tocVisible);
   tocEl.hidden = !tocVisible;
 
-  for (const btn of root.querySelectorAll<HTMLButtonElement>('button[data-ui-toggle="search"]')) {
+  for (const btn of root.querySelectorAll<HTMLButtonElement>(
+    'button[data-ui-toggle="search"]'
+  )) {
     btn.setAttribute('aria-expanded', String(searchUiVisible));
     btn.setAttribute('aria-pressed', String(searchUiVisible));
     btn.classList.toggle('is-active', searchUiVisible);
   }
-  for (const btn of root.querySelectorAll<HTMLButtonElement>('button[data-ui-toggle="toc"]')) {
+  for (const btn of root.querySelectorAll<HTMLButtonElement>(
+    'button[data-ui-toggle="toc"]'
+  )) {
     btn.setAttribute('aria-expanded', String(tocVisible));
     btn.setAttribute('aria-pressed', String(tocVisible));
     btn.classList.toggle('is-active', tocVisible);
   }
 }
 
-function buildRenderedHtmlExportSnapshot(): string {
+function buildRenderedHtmlExportSnapshot(): {
+  html: string;
+  themeVariables: Record<string, string>;
+} {
   const clone = renderer.getContentElement().cloneNode(true) as HTMLElement;
 
   // Remove transient search highlights/selection state.
-  for (const mark of clone.querySelectorAll<HTMLElement>('mark.omv-search-hit')) {
+  for (const mark of clone.querySelectorAll<HTMLElement>(
+    'mark.omv-search-hit'
+  )) {
     const parent = mark.parentNode;
     if (!parent) continue;
     while (mark.firstChild) {
@@ -339,7 +396,9 @@ function buildRenderedHtmlExportSnapshot(): string {
   }
 
   // Export Mermaid as static SVG content (no preview toolbar/pan-zoom controls).
-  for (const interactive of clone.querySelectorAll<HTMLElement>('.omv-mermaid-interactive')) {
+  for (const interactive of clone.querySelectorAll<HTMLElement>(
+    '.omv-mermaid-interactive'
+  )) {
     const svg = interactive.querySelector<SVGSVGElement>('svg');
     if (svg) {
       interactive.replaceWith(svg.cloneNode(true));
@@ -349,13 +408,18 @@ function buildRenderedHtmlExportSnapshot(): string {
   }
 
   // Remove preview-only state attrs.
-  for (const el of clone.querySelectorAll<HTMLElement>('[aria-current],[aria-busy]')) {
+  for (const el of clone.querySelectorAll<HTMLElement>(
+    '[aria-current],[aria-busy]'
+  )) {
     el.removeAttribute('aria-current');
     el.removeAttribute('aria-busy');
   }
 
   clone.normalize();
-  return clone.innerHTML;
+  return {
+    html: clone.innerHTML,
+    themeVariables: renderer.getComputedThemeVariables()
+  };
 }
 
 function blockRemoteNetworking(): void {
@@ -364,24 +428,36 @@ function blockRemoteNetworking(): void {
   // Defense-in-depth: CSP already denies outbound connections, but we also fail fast at runtime.
   const originalFetch = window.fetch.bind(window);
   window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
     if (isRemote(url)) {
-      throw new Error(`Remote fetch blocked in Offline Markdown Preview: ${url}`);
+      throw new Error(
+        `Remote fetch blocked in Offline Markdown Preview: ${url}`
+      );
     }
     return originalFetch(input, init);
   }) as typeof window.fetch;
 
   const originalOpen = XMLHttpRequest.prototype.open;
-  XMLHttpRequest.prototype.open = function patchedOpen(method: string, url: string | URL, ...rest: unknown[]) {
+  XMLHttpRequest.prototype.open = function patchedOpen(
+    method: string,
+    url: string | URL,
+    ...rest: unknown[]
+  ) {
     const target = typeof url === 'string' ? url : url.href;
     if (isRemote(target)) {
-      throw new Error(`Remote XHR blocked in Offline Markdown Preview: ${target}`);
+      throw new Error(
+        `Remote XHR blocked in Offline Markdown Preview: ${target}`
+      );
     }
-    return (originalOpen as unknown as (...args: unknown[]) => unknown).apply(this, [
-      method,
-      url,
-      ...rest
-    ]) as void;
+    return (originalOpen as unknown as (...args: unknown[]) => unknown).apply(
+      this,
+      [method, url, ...rest]
+    ) as void;
   };
 
   const WebSocketCtor = window.WebSocket;
@@ -389,7 +465,9 @@ function blockRemoteNetworking(): void {
     constructor(url: string | URL, protocols?: string | string[]) {
       const href = typeof url === 'string' ? url : url.href;
       if (/^wss?:\/\//i.test(href)) {
-        throw new Error(`WebSocket blocked in Offline Markdown Preview: ${href}`);
+        throw new Error(
+          `WebSocket blocked in Offline Markdown Preview: ${href}`
+        );
       }
       super(url, protocols);
     }
@@ -402,7 +480,9 @@ function blockRemoteNetworking(): void {
       constructor(url: string | URL, eventSourceInitDict?: EventSourceInit) {
         const href = typeof url === 'string' ? url : url.href;
         if (isRemote(href)) {
-          throw new Error(`EventSource blocked in Offline Markdown Preview: ${href}`);
+          throw new Error(
+            `EventSource blocked in Offline Markdown Preview: ${href}`
+          );
         }
         super(url, eventSourceInitDict);
       }

--- a/test/unit/helpers/vscodeMock.ts
+++ b/test/unit/helpers/vscodeMock.ts
@@ -48,6 +48,11 @@ export function createVscodeMock(workspaceRoot?: string) {
 
   return {
     Uri,
+    extensions: {
+      getExtension() {
+        return undefined;
+      }
+    },
     workspace: {
       workspaceFile: undefined,
       workspaceFolders,
@@ -55,10 +60,7 @@ export function createVscodeMock(workspaceRoot?: string) {
       getWorkspaceFolder(uri: Uri) {
         return workspaceFolders.find((folder) => {
           const rel = path.relative(folder.uri.fsPath, uri.fsPath);
-          return (
-            rel === '' ||
-            (!rel.startsWith('..') && !path.isAbsolute(rel))
-          );
+          return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
         });
       }
     }

--- a/test/unit/messagingValidation.test.ts
+++ b/test/unit/messagingValidation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseExtensionMessage, parseWebviewMessage } from '../../src/extension/messaging/validate';
+import {
+  parseExtensionMessage,
+  parseWebviewMessage
+} from '../../src/extension/messaging/validate';
 
 describe('messaging validation', () => {
   it('accepts valid webview messages', () => {
@@ -9,7 +12,26 @@ describe('messaging validation', () => {
   });
 
   it('rejects invalid webview message payloads', () => {
-    expect(() => parseWebviewMessage({ type: 'previewScroll', percent: 2 })).toThrow();
+    expect(() =>
+      parseWebviewMessage({ type: 'previewScroll', percent: 2 })
+    ).toThrow();
+  });
+
+  it('accepts HTML export snapshots with theme variables', () => {
+    const msg = parseWebviewMessage({
+      type: 'htmlExportSnapshot',
+      requestId: 1,
+      html: '<p>Rendered</p>',
+      themeVariables: {
+        '--omv-active-pre-bg': 'rgb(1, 2, 3)',
+        '--omv-mermaid-border': 'rgb(4, 5, 6)'
+      }
+    });
+    expect(msg).toMatchObject({
+      type: 'htmlExportSnapshot',
+      requestId: 1,
+      html: '<p>Rendered</p>'
+    });
   });
 
   it('accepts valid extension render message', () => {
@@ -26,7 +48,13 @@ describe('messaging validation', () => {
         enableMath: true,
         scrollSync: true,
         sanitizeHtml: true,
-        showFrontmatter: false
+        showFrontmatter: false,
+        githubMarkdownStyle: {
+          enabled: true,
+          colorMode: 'light',
+          lightTheme: 'light',
+          darkTheme: 'dark'
+        }
       }
     });
     expect(msg.type).toBe('render');

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -54,7 +54,9 @@ function createPreviewPanelTestContext(options: {
   customCssUris?: InstanceType<typeof Uri>[];
   baseCssText?: string;
 }) {
-  const workspaceFolders = options.workspaceFolderPaths.map(createWorkspaceFolder);
+  const workspaceFolders = options.workspaceFolderPaths.map(
+    createWorkspaceFolder
+  );
   const textDocumentChange = createEventHook<{
     document: { uri: InstanceType<typeof Uri> };
   }>();
@@ -66,16 +68,21 @@ function createPreviewPanelTestContext(options: {
     uri: InstanceType<typeof Uri>;
   }>();
   const configurationChange = createEventHook<{
-    affectsConfiguration: (section: string, resource?: InstanceType<typeof Uri>) => boolean;
+    affectsConfiguration: (
+      section: string,
+      resource?: InstanceType<typeof Uri>
+    ) => boolean;
   }>();
   const activeEditorChange = createEventHook<unknown>();
   const visibleRangesChange = createEventHook<unknown>();
   const update = vi.fn().mockResolvedValue(undefined);
   const showInformationMessage = vi.fn().mockResolvedValue(undefined);
   const showWarningMessage = vi.fn().mockResolvedValue(undefined);
-  const showOpenDialog = vi.fn().mockResolvedValue(
-    options.openDialogPath ? [Uri.file(options.openDialogPath)] : undefined
-  );
+  const showOpenDialog = vi
+    .fn()
+    .mockResolvedValue(
+      options.openDialogPath ? [Uri.file(options.openDialogPath)] : undefined
+    );
 
   const activeTextEditor = options.activeEditorPath
     ? {
@@ -115,6 +122,9 @@ function createPreviewPanelTestContext(options: {
         if (key === 'preview.autoOpen') {
           return false as T;
         }
+        if (key === 'preview.useMarkdownPreviewGithubStyling') {
+          return false as T;
+        }
         return defaultValue;
       },
       inspect<T>() {
@@ -126,10 +136,12 @@ function createPreviewPanelTestContext(options: {
       },
       update
     })),
-    onDidChangeTextDocument: (listener: Listener<{ document: { uri: InstanceType<typeof Uri> } }>) =>
-      textDocumentChange.register(listener),
-    onDidSaveTextDocument: (listener: Listener<{ uri: InstanceType<typeof Uri> }>) =>
-      textDocumentSave.register(listener),
+    onDidChangeTextDocument: (
+      listener: Listener<{ document: { uri: InstanceType<typeof Uri> } }>
+    ) => textDocumentChange.register(listener),
+    onDidSaveTextDocument: (
+      listener: Listener<{ uri: InstanceType<typeof Uri> }>
+    ) => textDocumentSave.register(listener),
     onDidCloseTextDocument: (
       listener: Listener<{ languageId: string; uri: InstanceType<typeof Uri> }>
     ) => textDocumentClose.register(listener),
@@ -148,6 +160,7 @@ function createPreviewPanelTestContext(options: {
     workspace,
     window: {
       activeTextEditor,
+      activeColorTheme: { kind: 2 },
       showQuickPick,
       showOpenDialog,
       showInformationMessage,
@@ -161,6 +174,12 @@ function createPreviewPanelTestContext(options: {
     EventEmitter,
     TreeItem: class {},
     TreeItemCollapsibleState: { None: 0 },
+    ColorThemeKind: {
+      Light: 1,
+      Dark: 2,
+      HighContrast: 3,
+      HighContrastLight: 4
+    },
     ViewColumn: {
       Active: 1,
       Beside: 2
@@ -193,9 +212,13 @@ function createPreviewPanelTestContext(options: {
     buildWebviewCsp: vi.fn(() => ''),
     confirmSanitizeDisabled: vi.fn(async () => true),
     createNonce: vi.fn(() => 'nonce'),
-    getConfiguredCustomCssUris: vi.fn(
-      () => options.customCssUris ?? []
-    ),
+    getConfiguredCustomCssUris: vi.fn(() => options.customCssUris ?? []),
+    getGithubMarkdownStyleSettings: vi.fn((enabled: boolean) => ({
+      enabled,
+      colorMode: 'light',
+      lightTheme: 'light',
+      darkTheme: 'dark'
+    })),
     getWorkspaceCustomCssBaseUri: vi.fn(() =>
       options.workspaceFilePath
         ? Uri.file(path.dirname(options.workspaceFilePath))
@@ -214,13 +237,14 @@ function createPreviewPanelTestContext(options: {
   };
 
   const fsMock = {
-    readFile: vi.fn().mockResolvedValue(
-      options.baseCssText ?? 'body { color: black; }'
-    )
+    readFile: vi
+      .fn()
+      .mockResolvedValue(options.baseCssText ?? 'body { color: black; }')
   };
 
   return {
     changeTextDocument: textDocumentChange.fire,
+    changeConfiguration: configurationChange.fire,
     closeTextDocument: textDocumentClose.fire,
     fsMock,
     renderMarkdown: vi.fn(() => ({
@@ -245,7 +269,10 @@ async function loadPreviewPanelTestModule(
   vi.doMock('../../src/extension/preview/markdown/markdownPipeline', () => ({
     renderMarkdown: context.renderMarkdown
   }));
-  vi.doMock('../../src/extension/preview/markdown/security', () => context.securityMock);
+  vi.doMock(
+    '../../src/extension/preview/markdown/security',
+    () => context.securityMock
+  );
   const module = await import('../../src/extension/preview/PreviewPanel');
   return { ...context, module };
 }
@@ -259,9 +286,54 @@ afterEach(() => {
 });
 
 describe('PreviewController custom CSS', () => {
+  it('enables installed GitHub Markdown styling in user settings', async () => {
+    const { module, update, vscodeMock } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-root/workspace-a'],
+      activeEditorPath: '/workspace-root/workspace-a/doc.md',
+      quickPickLabel: 'Use Installed GitHub Markdown Styling'
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    await controller.configureCustomCss();
+
+    expect(update).toHaveBeenCalledWith(
+      'preview.useMarkdownPreviewGithubStyling',
+      true,
+      vscodeMock.ConfigurationTarget.Global
+    );
+  });
+
+  it('disables installed GitHub Markdown styling in user settings', async () => {
+    const { module, update, vscodeMock } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-root/workspace-a'],
+      activeEditorPath: '/workspace-root/workspace-a/doc.md',
+      quickPickLabel: 'Disable Installed GitHub Markdown Styling'
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    await controller.configureCustomCss();
+
+    expect(update).toHaveBeenCalledWith(
+      'preview.useMarkdownPreviewGithubStyling',
+      false,
+      vscodeMock.ConfigurationTarget.Global
+    );
+  });
+
   it('writes workspace custom CSS to workspace settings', async () => {
     const { module, update, vscodeMock } = await loadPreviewPanelTestModule({
-      workspaceFolderPaths: ['/workspace-root/workspace-a', '/workspace-root/workspace-b'],
+      workspaceFolderPaths: [
+        '/workspace-root/workspace-a',
+        '/workspace-root/workspace-b'
+      ],
       workspaceFilePath: '/workspace-root/demo.code-workspace',
       activeEditorPath: '/workspace-root/workspace-a/doc.md',
       quickPickLabel: 'Set Workspace Custom CSS',
@@ -284,7 +356,10 @@ describe('PreviewController custom CSS', () => {
 
   it('clears folder custom CSS by removing the override', async () => {
     const { module, update, vscodeMock } = await loadPreviewPanelTestModule({
-      workspaceFolderPaths: ['/workspace-root/workspace-a', '/workspace-root/workspace-b'],
+      workspaceFolderPaths: [
+        '/workspace-root/workspace-a',
+        '/workspace-root/workspace-b'
+      ],
       workspaceFilePath: '/workspace-root/demo.code-workspace',
       activeEditorPath: '/workspace-root/workspace-a/doc.md',
       quickPickLabel: 'Clear Folder Custom CSS'
@@ -306,7 +381,10 @@ describe('PreviewController custom CSS', () => {
 
   it('scopes folder custom CSS to the active non-markdown editor folder', async () => {
     const { module, update, vscodeMock } = await loadPreviewPanelTestModule({
-      workspaceFolderPaths: ['/workspace-root/workspace-a', '/workspace-root/workspace-b'],
+      workspaceFolderPaths: [
+        '/workspace-root/workspace-a',
+        '/workspace-root/workspace-b'
+      ],
       workspaceFilePath: '/workspace-root/demo.code-workspace',
       activeEditorPath: '/workspace-root/workspace-b/notes.txt',
       activeEditorLanguageId: 'plaintext',
@@ -448,6 +526,38 @@ describe('PreviewController custom CSS', () => {
     expect(renderMarkdown).not.toHaveBeenCalled();
   });
 
+  it('marks webview CSS dirty when installed GitHub styling configuration changes', async () => {
+    const { changeConfiguration, module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a'],
+      activeEditorPath: '/workspace-a/doc.md'
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    (controller as any).currentEditor = {
+      document: {
+        languageId: 'markdown',
+        uri: Uri.file('/workspace-a/doc.md'),
+        lineCount: 1,
+        version: 1,
+        getText: () => '# Doc'
+      }
+    };
+    (controller as any).webviewCustomCssDirty = false;
+
+    changeConfiguration({
+      affectsConfiguration: (section: string) =>
+        section === 'offlineMarkdownViewer' ||
+        section ===
+          'offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling'
+    });
+
+    expect((controller as any).webviewCustomCssDirty).toBe(true);
+  });
+
   it('keeps custom CSS in separate style tags in standalone export HTML', async () => {
     const { module, securityMock } = await loadPreviewPanelTestModule({
       workspaceFolderPaths: ['/workspace-a']
@@ -456,6 +566,7 @@ describe('PreviewController custom CSS', () => {
     securityMock.resolveCustomCss.mockResolvedValue({
       key: 'export-custom-css',
       cssTexts: [
+        '.github-markdown-body { color: black; }',
         '.omv-content { color: red; }',
         '@import url("https://example.com/theme.css");'
       ]
@@ -471,6 +582,10 @@ describe('PreviewController custom CSS', () => {
       Uri.file('/workspace-a/doc.md'),
       {
         showFrontmatter: false
+      },
+      {
+        '--omv-active-pre-bg': 'rgb(1, 2, 3)',
+        '--omv-mermaid-border': 'rgb(4, 5, 6)'
       }
     );
 
@@ -479,13 +594,27 @@ describe('PreviewController custom CSS', () => {
     );
     expect(html).toContain('<style>body { color: black; }</style>');
     expect(html).toContain(
-      '<style data-omv-custom-css="0">.omv-content { color: red; }</style>'
+      '<style data-omv-custom-css="0">.github-markdown-body { color: black; }</style>'
     );
     expect(html).toContain(
-      '<style data-omv-custom-css="1">@import url("https://example.com/theme.css");</style>'
+      '<style data-omv-custom-css="1">.omv-content { color: red; }</style>'
+    );
+    expect(html).toContain(
+      '<style data-omv-custom-css="2">@import url("https://example.com/theme.css");</style>'
+    );
+    expect(html).toContain(
+      '<div class="omv-content markdown-body github-markdown-body" data-color-mode="light" data-light-theme="light" data-dark-theme="dark" style="--omv-active-pre-bg: rgb(1, 2, 3); --omv-mermaid-border: rgb(4, 5, 6);">'
+    );
+    expect(html).toContain('<div class="github-markdown-content">');
+    expect(html).toContain('<body class="vscode-body vscode-dark">');
+    expect(html).toContain(
+      '<div class="github-markdown-content">\n<p>Rendered</p>\n</div>'
     );
     expect(html.indexOf('<style data-omv-custom-css="0">')).toBeLessThan(
       html.indexOf('<style data-omv-custom-css="1">')
+    );
+    expect(html.indexOf('<style data-omv-custom-css="1">')).toBeLessThan(
+      html.indexOf('<style data-omv-custom-css="2">')
     );
   });
 });

--- a/test/unit/security.test.ts
+++ b/test/unit/security.test.ts
@@ -18,6 +18,14 @@ function createConfiguredVscodeMock(options: {
   workspaceRoot?: string;
   workspaceFolderPaths?: string[];
   workspaceFilePath?: string;
+  useMarkdownPreviewGithubStyling?: boolean;
+  githubMarkdownExtension?: {
+    extensionPath: string;
+    previewStyles?: unknown;
+  };
+  githubStyleColorTheme?: string;
+  githubStyleLightTheme?: string;
+  githubStyleDarkTheme?: string;
   globalCustomCssPath?: string;
   workspaceCustomCssPath?: string;
   workspaceFolderCustomCssPath?: string;
@@ -64,6 +72,12 @@ function createConfiguredVscodeMock(options: {
               return {
                 globalValue: options.globalCustomCssPath as T | undefined
               };
+            case 'preview.useMarkdownPreviewGithubStyling':
+              return {
+                globalValue: options.useMarkdownPreviewGithubStyling as
+                  | T
+                  | undefined
+              };
             case 'preview.customCssPath':
               return {
                 workspaceValue: options.workspaceCustomCssPath as T | undefined,
@@ -75,9 +89,52 @@ function createConfiguredVscodeMock(options: {
               return {};
           }
         },
-        get<T>(_key: string, defaultValue: T): T {
+        get<T>(key: string, defaultValue: T): T {
+          if (key === 'preview.useMarkdownPreviewGithubStyling') {
+            return (
+              (options.useMarkdownPreviewGithubStyling as T | undefined) ??
+              defaultValue
+            );
+          }
+          if (key === 'colorTheme') {
+            return (
+              (options.githubStyleColorTheme as T | undefined) ?? defaultValue
+            );
+          }
+          if (key === 'lightTheme') {
+            return (
+              (options.githubStyleLightTheme as T | undefined) ?? defaultValue
+            );
+          }
+          if (key === 'darkTheme') {
+            return (
+              (options.githubStyleDarkTheme as T | undefined) ?? defaultValue
+            );
+          }
           return defaultValue;
         }
+      })
+    },
+    extensions: {
+      getExtension: vi.fn((id: string) => {
+        if (
+          id !== 'bierner.markdown-preview-github-styles' ||
+          !options.githubMarkdownExtension
+        ) {
+          return undefined;
+        }
+
+        return {
+          extensionUri: base.Uri.file(
+            options.githubMarkdownExtension.extensionPath
+          ),
+          packageJSON: {
+            contributes: {
+              'markdown.previewStyles':
+                options.githubMarkdownExtension.previewStyles
+            }
+          }
+        };
       })
     },
     window: {
@@ -94,6 +151,14 @@ async function loadSecurity(
     workspaceRoot?: string;
     workspaceFolderPaths?: string[];
     workspaceFilePath?: string;
+    useMarkdownPreviewGithubStyling?: boolean;
+    githubMarkdownExtension?: {
+      extensionPath: string;
+      previewStyles?: unknown;
+    };
+    githubStyleColorTheme?: string;
+    githubStyleLightTheme?: string;
+    githubStyleDarkTheme?: string;
     globalCustomCssPath?: string;
     workspaceCustomCssPath?: string;
     workspaceFolderCustomCssPath?: string;
@@ -159,6 +224,129 @@ describe('security helpers', () => {
 
     expect(result.cssTexts).toEqual([]);
     expect(warnings).toEqual([]);
+  });
+
+  it('reads GitHub preview style theme settings with defaults', async () => {
+    const { security } = await loadSecurity();
+    expect(security.getGithubMarkdownStyleSettings(true)).toEqual({
+      enabled: true,
+      colorMode: 'auto',
+      lightTheme: 'light',
+      darkTheme: 'dark'
+    });
+  });
+
+  it('reads configured GitHub preview style theme settings', async () => {
+    const { security } = await loadSecurity({
+      githubStyleColorTheme: 'light',
+      githubStyleLightTheme: 'light_high_contrast',
+      githubStyleDarkTheme: 'dark_dimmed'
+    });
+    expect(security.getGithubMarkdownStyleSettings(true)).toEqual({
+      enabled: true,
+      colorMode: 'light',
+      lightTheme: 'light_high_contrast',
+      darkTheme: 'dark_dimmed'
+    });
+  });
+
+  it('loads installed GitHub preview styles before user custom CSS', async () => {
+    const workspaceRoot = await makeTempDir();
+    const extensionPath = await makeTempDir();
+    const globalPath = path.join(workspaceRoot, 'global.css');
+    const workspaceCssPath = path.join(workspaceRoot, 'styles', 'preview.css');
+    const githubBasePath = path.join(extensionPath, 'dist', 'github-base.css');
+    const githubThemePath = path.join(
+      extensionPath,
+      'dist',
+      'github-theme.css'
+    );
+    await fs.mkdir(path.dirname(workspaceCssPath), { recursive: true });
+    await fs.mkdir(path.dirname(githubBasePath), { recursive: true });
+    await fs.writeFile(
+      githubBasePath,
+      '.markdown-body { color: black; }',
+      'utf8'
+    );
+    await fs.writeFile(
+      githubThemePath,
+      '.markdown-body h1 { color: blue; }',
+      'utf8'
+    );
+    await fs.writeFile(globalPath, 'body { color: red; }', 'utf8');
+    await fs.writeFile(workspaceCssPath, 'body { color: green; }', 'utf8');
+
+    const { security, vscodeMock, warnings } = await loadSecurity({
+      workspaceRoot,
+      useMarkdownPreviewGithubStyling: true,
+      githubMarkdownExtension: {
+        extensionPath,
+        previewStyles: ['dist/github-base.css', 'dist/github-theme.css']
+      },
+      globalCustomCssPath: globalPath,
+      workspaceCustomCssPath: 'styles/preview.css'
+    });
+    const result = await security.resolveCustomCss(
+      vscodeMock.Uri.file(path.join(workspaceRoot, 'doc.md'))
+    );
+
+    expect(result.cssTexts).toEqual([
+      '.markdown-body { color: black; }',
+      '.markdown-body h1 { color: blue; }',
+      'body { color: red; }',
+      'body { color: green; }'
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns when installed GitHub preview styling is enabled but the extension is missing', async () => {
+    const workspaceRoot = await makeTempDir();
+    const { security, vscodeMock, warnings } = await loadSecurity({
+      workspaceRoot,
+      useMarkdownPreviewGithubStyling: true
+    });
+    const result = await security.resolveCustomCss(
+      vscodeMock.Uri.file(path.join(workspaceRoot, 'doc.md'))
+    );
+
+    expect(result.cssTexts).toEqual([]);
+    expect(warnings).toEqual([
+      'GitHub Markdown styling is enabled, but bierner.markdown-preview-github-styles is not installed.'
+    ]);
+  });
+
+  it('ignores non-css and missing contributed GitHub preview style paths', async () => {
+    const workspaceRoot = await makeTempDir();
+    const extensionPath = await makeTempDir();
+    const githubCssPath = path.join(extensionPath, 'dist', 'github-base.css');
+    await fs.mkdir(path.dirname(githubCssPath), { recursive: true });
+    await fs.writeFile(
+      githubCssPath,
+      '.markdown-body { color: black; }',
+      'utf8'
+    );
+
+    const { security, vscodeMock, warnings } = await loadSecurity({
+      workspaceRoot,
+      useMarkdownPreviewGithubStyling: true,
+      githubMarkdownExtension: {
+        extensionPath,
+        previewStyles: [
+          'dist/github-base.css',
+          'dist/missing.css',
+          'dist/not-css.txt',
+          42
+        ]
+      }
+    });
+    const result = await security.resolveCustomCss(
+      vscodeMock.Uri.file(path.join(workspaceRoot, 'doc.md'))
+    );
+
+    expect(result.cssTexts).toEqual(['.markdown-body { color: black; }']);
+    expect(warnings).toEqual([
+      'Could not read one or more CSS files from bierner.markdown-preview-github-styles.'
+    ]);
   });
 
   it('loads global CSS from an absolute .css path', async () => {
@@ -418,6 +606,47 @@ describe('security helpers', () => {
     expect(first.key).not.toBe(second.key);
     expect(first.cssTexts).toEqual(['body { color: red; }']);
     expect(second.cssTexts).toEqual(['body { color: blue; }']);
+  });
+
+  it('changes the custom CSS key when installed GitHub preview style contents change', async () => {
+    const workspaceRoot = await makeTempDir();
+    const extensionPath = await makeTempDir();
+    const githubCssPath = path.join(extensionPath, 'dist', 'github-base.css');
+
+    const { security, vscodeMock } = await loadSecurity({
+      workspaceRoot,
+      useMarkdownPreviewGithubStyling: true,
+      githubMarkdownExtension: {
+        extensionPath,
+        previewStyles: ['dist/github-base.css']
+      },
+      openTextDocuments: [
+        { fsPath: githubCssPath, text: '.markdown-body { color: red; }' }
+      ]
+    });
+    const first = await security.resolveCustomCss(
+      vscodeMock.Uri.file(path.join(workspaceRoot, 'doc.md'))
+    );
+
+    const { security: updatedSecurity, vscodeMock: updatedVscodeMock } =
+      await loadSecurity({
+        workspaceRoot,
+        useMarkdownPreviewGithubStyling: true,
+        githubMarkdownExtension: {
+          extensionPath,
+          previewStyles: ['dist/github-base.css']
+        },
+        openTextDocuments: [
+          { fsPath: githubCssPath, text: '.markdown-body { color: blue; }' }
+        ]
+      });
+    const second = await updatedSecurity.resolveCustomCss(
+      updatedVscodeMock.Uri.file(path.join(workspaceRoot, 'doc.md'))
+    );
+
+    expect(first.key).not.toBe(second.key);
+    expect(first.cssTexts).toEqual(['.markdown-body { color: red; }']);
+    expect(second.cssTexts).toEqual(['.markdown-body { color: blue; }']);
   });
 
   it('changes the custom CSS key when a missing file later appears', async () => {

--- a/test/unit/themeUtils.test.ts
+++ b/test/unit/themeUtils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getEffectiveMermaidThemeKind,
+  getThemeKindFromBodyClass,
+  normalizeObservedBodyClass,
+  shouldRefreshTheme
+} from '../../src/webview-ui/app/themeUtils';
+
+describe('theme utils', () => {
+  it('normalizes observed body classes and keeps vscode-body present', () => {
+    expect(
+      normalizeObservedBodyClass('vscode-light theme-a custom-class')
+    ).toBe('custom-class theme-a vscode-body vscode-light');
+  });
+
+  it('adds a light or dark class for high-contrast body classes', () => {
+    expect(normalizeObservedBodyClass('theme-a vscode-high-contrast')).toBe(
+      'theme-a vscode-body vscode-dark vscode-high-contrast'
+    );
+    expect(
+      normalizeObservedBodyClass('theme-b vscode-high-contrast-light')
+    ).toBe(
+      'theme-b vscode-body vscode-high-contrast vscode-high-contrast-light vscode-light'
+    );
+  });
+
+  it('keeps theme kind detection stable after normalization', () => {
+    expect(
+      getThemeKindFromBodyClass(
+        normalizeObservedBodyClass('theme-a vscode-light')
+      )
+    ).toBe('light');
+    expect(
+      getThemeKindFromBodyClass(
+        normalizeObservedBodyClass('theme-b vscode-dark')
+      )
+    ).toBe('dark');
+    expect(
+      getThemeKindFromBodyClass(
+        normalizeObservedBodyClass('theme-c vscode-high-contrast')
+      )
+    ).toBe('high-contrast');
+  });
+
+  it('refreshes when the observed theme classes change within the same theme kind', () => {
+    const previous = normalizeObservedBodyClass('theme-a vscode-light');
+    const next = normalizeObservedBodyClass('theme-b vscode-light');
+
+    expect(shouldRefreshTheme(undefined, previous)).toBe(false);
+    expect(shouldRefreshTheme(previous, previous)).toBe(false);
+    expect(shouldRefreshTheme(previous, next)).toBe(true);
+  });
+
+  it('preserves high-contrast Mermaid styling on light high-contrast themes', () => {
+    expect(
+      getEffectiveMermaidThemeKind('rgb(255, 255, 255)', 'high-contrast')
+    ).toBe('high-contrast');
+  });
+
+  it('uses background luminance for non-high-contrast Mermaid themes', () => {
+    expect(getEffectiveMermaidThemeKind('rgb(255, 255, 255)', 'light')).toBe(
+      'light'
+    );
+    expect(getEffectiveMermaidThemeKind('rgb(30, 30, 30)', 'light')).toBe(
+      'dark'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add support for importing CSS from the installed `bierner.markdown-preview-github-styles` extension
- expose GitHub markdown style settings through the preview messaging protocol and validation layer
- capture computed theme variables in HTML export snapshots so exported HTML/PDF better matches the live preview
- refresh preview theming when VS Code theme classes or GitHub-style settings change
- document the new preview styling workflow and add unit coverage for theme utilities, security helpers, preview behavior, and messaging validation

## Testing
- `yarn --ignore-engines test:unit test/unit/security.test.ts test/unit/previewPanel.test.ts test/unit/themeUtils.test.ts test/unit/messagingValidation.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional integration with the GitHub markdown-preview-github-styles extension via a new setting to automatically apply GitHub styling to previews.
  * Enhanced preview styling with multi-layer CSS support: base styles → optional GitHub styling → global custom CSS → workspace/folder custom CSS.

* **Improvements**
  * Improved theme detection and colour handling for previews and exports.
  * HTML exports now preserve theme information for better styled output.

* **Documentation**
  * Updated styling setup documentation to explain the new multi-layer preview styling system and GitHub styling integration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->