### PR TITLE
FR - Persist preview search and ToC visibility across webview sessions

### DIFF
--- a/src/extension/messaging/protocol.ts
+++ b/src/extension/messaging/protocol.ts
@@ -131,6 +131,12 @@ export interface SearchRequestMessage {
   query?: string;
 }
 
+export interface UiStateChangedMessage {
+  type: 'uiStateChanged';
+  searchUiVisible: boolean;
+  tocVisible: boolean;
+}
+
 export interface PdfExportResultMessage {
   type: 'pdfExportResult';
   ok: boolean;
@@ -165,6 +171,7 @@ export type WebviewToExtensionMessage =
   | HeadingSelectedMessage
   | CopyHeadingLinkMessage
   | SearchRequestMessage
+  | UiStateChangedMessage
   | PdfExportResultMessage
   | OpenImageMessage
   | DownloadRemoteImageMessage

--- a/src/extension/messaging/validate.ts
+++ b/src/extension/messaging/validate.ts
@@ -33,6 +33,11 @@ const webviewSchema = z.discriminatedUnion('type', [
     query: z.string().optional()
   }),
   z.object({
+    type: z.literal('uiStateChanged'),
+    searchUiVisible: z.boolean(),
+    tocVisible: z.boolean()
+  }),
+  z.object({
     type: z.literal('pdfExportResult'),
     ok: z.boolean(),
     error: z.string().optional()

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -34,6 +34,11 @@ interface PreviewPanelState {
   toc: TocItem[];
 }
 
+interface PreviewUiState {
+  searchUiVisible: boolean;
+  tocVisible: boolean;
+}
+
 interface HtmlExportSnapshotData {
   html: string;
   themeVariables?: Record<string, string>;
@@ -136,6 +141,12 @@ function buildGitHubMarkdownStyleAttributes(enabled: boolean): string {
   return ` data-color-mode="${githubStyle.colorMode}" data-light-theme="${githubStyle.lightTheme}" data-dark-theme="${githubStyle.darkTheme}"`;
 }
 
+const PREVIEW_UI_STATE_KEY = 'preview.uiState';
+const DEFAULT_PREVIEW_UI_STATE: PreviewUiState = {
+  searchUiVisible: true,
+  tocVisible: true
+};
+
 export class MarkdownOutlineProvider
   implements vscode.TreeDataProvider<TocItem>, vscode.Disposable
 {
@@ -180,6 +191,7 @@ export class PreviewController implements vscode.Disposable {
   private panel: vscode.WebviewPanel | undefined;
   private currentEditor: vscode.TextEditor | undefined;
   private state: PreviewPanelState = { toc: [] };
+  private previewUiState: PreviewUiState;
   private renderRequestId = 0;
   private renderTimer: NodeJS.Timeout | undefined;
   private suppressEditorScrollUntil = 0;
@@ -209,6 +221,7 @@ export class PreviewController implements vscode.Disposable {
   readonly onOutlineChanged = this.outlineEmitter.event;
 
   constructor(private readonly context: vscode.ExtensionContext) {
+    this.previewUiState = this.readPreviewUiState();
     this.disposables.push(
       vscode.workspace.onDidChangeTextDocument((e) => {
         if (!this.currentEditor) {
@@ -1151,6 +1164,13 @@ export class PreviewController implements vscode.Disposable {
         // Search runs in webview UI; command exists for future extension-driven search actions.
         break;
       }
+      case 'uiStateChanged': {
+        await this.updatePreviewUiState({
+          searchUiVisible: message.searchUiVisible,
+          tocVisible: message.tocVisible
+        });
+        break;
+      }
       case 'pdfExportResult': {
         if (!message.ok && message.error) {
           void vscode.window.showWarningMessage(
@@ -1259,11 +1279,38 @@ export class PreviewController implements vscode.Disposable {
 <body>
   <div id="app"></div>
   <script nonce="${nonce}">
-    window.__OMV_BOOT__ = { platform: ${JSON.stringify(process.platform)}, styleNonce: ${JSON.stringify(nonce)} };
+    window.__OMV_BOOT__ = {
+      platform: ${JSON.stringify(process.platform)},
+      styleNonce: ${JSON.stringify(nonce)},
+      initialUiState: ${JSON.stringify(this.previewUiState)}
+    };
   </script>
   <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>
 </html>`;
+  }
+
+  private readPreviewUiState(): PreviewUiState {
+    const saved = this.context.globalState?.get<Partial<PreviewUiState>>(
+      PREVIEW_UI_STATE_KEY
+    );
+    return {
+      searchUiVisible:
+        saved?.searchUiVisible ?? DEFAULT_PREVIEW_UI_STATE.searchUiVisible,
+      tocVisible: saved?.tocVisible ?? DEFAULT_PREVIEW_UI_STATE.tocVisible
+    };
+  }
+
+  private async updatePreviewUiState(next: PreviewUiState): Promise<void> {
+    if (
+      this.previewUiState.searchUiVisible === next.searchUiVisible &&
+      this.previewUiState.tocVisible === next.tocVisible
+    ) {
+      return;
+    }
+
+    this.previewUiState = next;
+    await this.context.globalState?.update?.(PREVIEW_UI_STATE_KEY, next);
   }
 
   private async refreshWebviewShellIfNeeded(

--- a/src/webview-ui/index.ts
+++ b/src/webview-ui/index.ts
@@ -231,7 +231,11 @@ window.addEventListener('keydown', (event) => {
     event.key.toLowerCase() === 'f'
   ) {
     event.preventDefault();
-    setSearchUiVisible(true, { focus: true, select: true });
+    setSearchUiVisible(true, {
+      focus: true,
+      select: true,
+      persistPreference: true
+    });
     persistState();
   }
 });
@@ -273,7 +277,11 @@ async function handleMessage(
     }
     case 'searchCommand': {
       if (message.action === 'open') {
-        setSearchUiVisible(true, { focus: true, select: true });
+        setSearchUiVisible(true, {
+          focus: true,
+          select: true,
+          persistPreference: true
+        });
       } else if (message.action === 'next') {
         search.next();
       } else if (message.action === 'prev') {

--- a/src/webview-ui/index.ts
+++ b/src/webview-ui/index.ts
@@ -27,6 +27,15 @@ interface ViewState {
   tocVisible?: boolean;
 }
 
+interface BootData {
+  platform?: string;
+  styleNonce?: string;
+  initialUiState?: {
+    searchUiVisible?: boolean;
+    tocVisible?: boolean;
+  };
+}
+
 const CUSTOM_CSS_STYLE_SELECTOR = 'style[data-omv-custom-css="true"]';
 
 const vscode = acquireVsCodeApi();
@@ -83,10 +92,12 @@ if (
 }
 
 const state = (vscode.getState() as ViewState | undefined) ?? {};
+const boot = getBootData();
 
 let lastRender: RenderPayload | undefined;
-let searchUiVisible = state.searchUiVisible ?? true;
-let tocVisible = state.tocVisible ?? true;
+let searchUiVisible =
+  state.searchUiVisible ?? boot.initialUiState?.searchUiVisible ?? true;
+let tocVisible = state.tocVisible ?? boot.initialUiState?.tocVisible ?? true;
 
 const renderer = new PreviewRenderer(article, {
   onOpenLink(href, kindHint) {
@@ -158,7 +169,8 @@ for (const btn of root.querySelectorAll<HTMLButtonElement>(
     const target = btn.dataset.uiToggle;
     if (target === 'search') {
       setSearchUiVisible(!searchUiVisible, {
-        focus: searchUiVisible ? false : true
+        focus: searchUiVisible ? false : true,
+        persistPreference: true
       });
     }
     if (target === 'toc') {
@@ -324,9 +336,13 @@ function applyCustomCss(cssTexts: string[]): void {
 }
 
 function getBootStyleNonce(): string | undefined {
-  const boot = (window as Window & { __OMV_BOOT__?: { styleNonce?: string } })
-    .__OMV_BOOT__;
+  const boot = getBootData();
   return boot?.styleNonce;
+}
+
+function getBootData(): BootData {
+  return ((window as Window & { __OMV_BOOT__?: BootData }).__OMV_BOOT__ ??
+    {}) as BootData;
 }
 
 function persistState(): void {
@@ -339,10 +355,15 @@ function persistState(): void {
 
 function setSearchUiVisible(
   visible: boolean,
-  options: { focus?: boolean; select?: boolean } = {}
+  options: { focus?: boolean; select?: boolean; persistPreference?: boolean } = {}
 ): void {
-  searchUiVisible = visible;
-  applyUiVisibility();
+  if (searchUiVisible !== visible) {
+    searchUiVisible = visible;
+    applyUiVisibility();
+    if (options.persistPreference) {
+      persistUiPreference();
+    }
+  }
   if (visible && options.focus) {
     searchInput.focus();
     if (options.select) {
@@ -352,8 +373,19 @@ function setSearchUiVisible(
 }
 
 function setTocVisible(visible: boolean): void {
-  tocVisible = visible;
-  applyUiVisibility();
+  if (tocVisible !== visible) {
+    tocVisible = visible;
+    applyUiVisibility();
+    persistUiPreference();
+  }
+}
+
+function persistUiPreference(): void {
+  vscode.postMessage({
+    type: 'uiStateChanged',
+    searchUiVisible,
+    tocVisible
+  });
 }
 
 function applyUiVisibility(): void {

--- a/test/unit/messagingValidation.test.ts
+++ b/test/unit/messagingValidation.test.ts
@@ -34,6 +34,19 @@ describe('messaging validation', () => {
     });
   });
 
+  it('accepts preview UI state change messages', () => {
+    const msg = parseWebviewMessage({
+      type: 'uiStateChanged',
+      searchUiVisible: false,
+      tocVisible: true
+    });
+    expect(msg).toMatchObject({
+      type: 'uiStateChanged',
+      searchUiVisible: false,
+      tocVisible: true
+    });
+  });
+
   it('accepts valid extension render message', () => {
     const msg = parseExtensionMessage({
       type: 'render',

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -53,6 +53,10 @@ function createPreviewPanelTestContext(options: {
   openDialogPath?: string;
   customCssUris?: InstanceType<typeof Uri>[];
   baseCssText?: string;
+  initialPreviewUiState?: {
+    searchUiVisible?: boolean;
+    tocVisible?: boolean;
+  };
 }) {
   const workspaceFolders = options.workspaceFolderPaths.map(
     createWorkspaceFolder
@@ -83,6 +87,10 @@ function createPreviewPanelTestContext(options: {
     .mockResolvedValue(
       options.openDialogPath ? [Uri.file(options.openDialogPath)] : undefined
     );
+  const globalStateGet = vi.fn((key: string) =>
+    key === 'preview.uiState' ? options.initialPreviewUiState : undefined
+  );
+  const globalStateUpdate = vi.fn().mockResolvedValue(undefined);
 
   const activeTextEditor = options.activeEditorPath
     ? {
@@ -247,6 +255,10 @@ function createPreviewPanelTestContext(options: {
     changeConfiguration: configurationChange.fire,
     closeTextDocument: textDocumentClose.fire,
     fsMock,
+    globalState: {
+      get: globalStateGet,
+      update: globalStateUpdate
+    },
     renderMarkdown: vi.fn(() => ({
       html: '<p>Rendered</p>',
       toc: [],
@@ -616,5 +628,70 @@ describe('PreviewController custom CSS', () => {
     expect(html.indexOf('<style data-omv-custom-css="1">')).toBeLessThan(
       html.indexOf('<style data-omv-custom-css="2">')
     );
+  });
+
+  it('hydrates new webviews with the saved preview UI toggle state', async () => {
+    const { globalState, module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a'],
+      initialPreviewUiState: {
+        searchUiVisible: false,
+        tocVisible: false
+      }
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage'),
+      globalState
+    } as any);
+
+    const html = await (controller as any).buildWebviewHtml(
+      {
+        asWebviewUri: (uri: InstanceType<typeof Uri>) => uri,
+        cspSource: 'webview-source'
+      },
+      {
+        enableMermaid: true,
+        enableMath: true,
+        scrollSync: true,
+        sanitizeHtml: true,
+        autoOpenPreview: false,
+        allowRemoteImages: false,
+        showFrontmatter: false,
+        externalConfirm: true,
+        maxImageMB: 8,
+        embedImages: false,
+        debounceMs: 120,
+        useMarkdownPreviewGithubStyling: false
+      }
+    );
+
+    expect(globalState.get).toHaveBeenCalledWith('preview.uiState');
+    expect(html).toContain(
+      'initialUiState: {"searchUiVisible":false,"tocVisible":false}'
+    );
+  });
+
+  it('persists preview UI toggle changes from the webview', async () => {
+    const { globalState, module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a']
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage'),
+      globalState
+    } as any);
+
+    await (controller as any).handleWebviewMessage({
+      type: 'uiStateChanged',
+      searchUiVisible: false,
+      tocVisible: true
+    });
+
+    expect(globalState.update).toHaveBeenCalledWith('preview.uiState', {
+      searchUiVisible: false,
+      tocVisible: true
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR saves the preview UI toggle state for the search bar and table of contents, then restores that state when a new preview webview is created.

## What changed
- Added a new `uiStateChanged` webview-to-extension message to the preview messaging protocol
- Validated the new message shape in the messaging schema
- Stored preview UI state in extension `globalState`
- Injected the saved UI state into webview boot data for new preview instances
- Updated the webview to initialize from saved preferences and persist changes when users toggle search or ToC visibility
- Added unit coverage for message validation, boot-time hydration, and persistence

## Why
Previously, search and ToC visibility only lived in the current webview state, so those preferences were lost when the preview was recreated. This makes the preview feel more consistent across reopen/reload flows.

## Testing
- Added unit tests for `uiStateChanged` message parsing
- Added unit tests for restoring saved UI state into new webviews
- Added unit tests for persisting UI toggle changes from the webview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and table-of-contents visibility are persisted and restored across sessions; toggles synchronise between the preview and the host.
  * Webview now sends UI preference updates to the host so state remains consistent and redundant UI updates are avoided.

* **Tests**
  * Added unit tests for UI-state validation, persistence and message handling between webview and host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->