### PR TITLE
Fix raw HTML GIF rendering in preview and bump extension version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.3.0
 
 - Add `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` to import CSS directly from the installed `bierner.markdown-preview-github-styles` extension
 - Make the preview/export markdown root compatible with GitHub-style `.markdown-body` selectors while keeping OMV chrome outside that styled content root
 - Extend the preview styling command and docs so installed GitHub styling can be enabled without copying versioned extension CSS paths
+- Rewrite local image paths inside raw HTML `<img>` tags so README/table-based GIF demos render correctly in the preview webview
+- Raise the default `offlineMarkdownViewer.preview.maxImageMB` limit from `8` MB to `24` MB so the bundled README demo GIFs render in preview without extra configuration
+- Persist search panel visibility inside the preview so it stays in the preferred state across refreshes and reopened panels
+- Persist table-of-contents visibility changes made in the preview UI
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ These VS Code settings control rendering, safety, and performance:
 - `offlineMarkdownViewer.preview.autoOpen` (default: `true`): auto-open/reuse preview when a Markdown editor becomes active.
 - `offlineMarkdownViewer.preview.allowRemoteImages` (default: `false`): allow loading remote `http(s)` images in preview. When off, remote images are shown as a download action and cached locally for preview use.
 - `offlineMarkdownViewer.preview.useMarkdownPreviewGithubStyling` (default: `false`): load CSS from the installed `bierner.markdown-preview-github-styles` extension before any configured custom CSS, while respecting that extension's `colorTheme`, `lightTheme`, and `darkTheme` settings.
-- `offlineMarkdownViewer.preview.maxImageMB` (default: `8`): maximum local image size loaded into preview.
+- `offlineMarkdownViewer.preview.maxImageMB` (default: `24`): maximum local image size loaded into preview.
 - `offlineMarkdownViewer.export.embedImages` (default: `false`): embed local images as data URIs for HTML export (privacy warning shown).
 - `offlineMarkdownViewer.performance.debounceMs` (default: `120`): debounce delay for live preview updates.
 - `offlineMarkdownViewer.preview.globalCustomCssPath` (default: `""`): absolute path to a user-level `.css` file appended to every preview.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offline-markdown-preview",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offline-markdown-preview",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "offline-markdown-preview",
   "displayName": "Offline Markdown Preview",
   "description": "Offline Markdown preview for VS Code with Mermaid diagrams, KaTeX math, secure local rendering, export, scroll sync, and outline navigation.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "bowlerr",
   "author": {
     "name": "Bowlerr",
@@ -152,7 +152,7 @@
         },
         "offlineMarkdownViewer.preview.maxImageMB": {
           "type": "number",
-          "default": 8,
+          "default": 24,
           "minimum": 1,
           "maximum": 100,
           "description": "Maximum image size loaded into preview (megabytes)."

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -13,6 +13,11 @@ import type {
 } from '../messaging/protocol';
 import { parseWebviewMessage } from '../messaging/validate';
 import {
+  OMV_EXPORT_SRCSET_ATTR,
+  OMV_LOCAL_SRC_ATTR,
+  OMV_REMOTE_SRC_ATTR
+} from '../../previewImageMetadata';
+import {
   getHtmlAttribute,
   mapHtmlImgTags,
   mapHtmlImgTagsAsync,
@@ -1765,7 +1770,7 @@ export class PreviewController implements vscode.Disposable {
         return tag;
       }
 
-      const localSrc = getHtmlAttribute(parsed.attributes, 'data-local-src')
+      const localSrc = getHtmlAttribute(parsed.attributes, OMV_LOCAL_SRC_ATTR)
         ?.value;
       const exportSrcset = getHtmlAttribute(parsed.attributes, 'srcset')?.value;
       let changed = false;
@@ -1828,13 +1833,13 @@ export class PreviewController implements vscode.Disposable {
         return tag;
       }
 
-      const localSrc = getHtmlAttribute(parsed.attributes, 'data-local-src')
+      const localSrc = getHtmlAttribute(parsed.attributes, OMV_LOCAL_SRC_ATTR)
         ?.value;
-      const remoteSrc = getHtmlAttribute(parsed.attributes, 'data-remote-src')
+      const remoteSrc = getHtmlAttribute(parsed.attributes, OMV_REMOTE_SRC_ATTR)
         ?.value;
       const exportSrcset = getHtmlAttribute(
         parsed.attributes,
-        'data-export-srcset'
+        OMV_EXPORT_SRCSET_ATTR
       )?.value;
       if (!localSrc && !remoteSrc && !exportSrcset) {
         return tag;

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -1830,16 +1830,20 @@ export class PreviewController implements vscode.Disposable {
 
       const localSrc = getHtmlAttribute(parsed.attributes, 'data-local-src')
         ?.value;
+      const remoteSrc = getHtmlAttribute(parsed.attributes, 'data-remote-src')
+        ?.value;
       const exportSrcset = getHtmlAttribute(
         parsed.attributes,
         'data-export-srcset'
       )?.value;
-      if (!localSrc && !exportSrcset) {
+      if (!localSrc && !remoteSrc && !exportSrcset) {
         return tag;
       }
 
       if (localSrc) {
         setHtmlAttribute(parsed.attributes, 'src', localSrc);
+      } else if (remoteSrc) {
+        setHtmlAttribute(parsed.attributes, 'src', remoteSrc);
       }
       if (exportSrcset) {
         setHtmlAttribute(parsed.attributes, 'srcset', exportSrcset);

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -86,7 +86,7 @@ function getSettings(resource?: vscode.Uri): RuntimeSettings {
     allowRemoteImages: cfg.get<boolean>('preview.allowRemoteImages', false),
     showFrontmatter: cfg.get<boolean>('preview.showFrontmatter', false),
     externalConfirm: cfg.get<boolean>('externalLinks.confirm', true),
-    maxImageMB: cfg.get<number>('preview.maxImageMB', 8),
+    maxImageMB: cfg.get<number>('preview.maxImageMB', 24),
     embedImages: cfg.get<boolean>('export.embedImages', false),
     debounceMs: cfg.get<number>('performance.debounceMs', 120),
     useMarkdownPreviewGithubStyling: cfg.get<boolean>(

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -59,6 +59,13 @@ interface HtmlExportSnapshotData {
   themeVariables?: Record<string, string>;
 }
 
+function withSvgFragment(url: string, uri: vscode.Uri): string {
+  if (!uri.fragment || path.extname(uri.fsPath || uri.path).toLowerCase() !== '.svg') {
+    return url;
+  }
+  return `${url}#${uri.fragment}`;
+}
+
 interface RuntimeSettings {
   enableMermaid: boolean;
   enableMath: boolean;
@@ -1781,7 +1788,11 @@ export class PreviewController implements vscode.Disposable {
         if (bytes > 0 && bytes <= maxImageMB * 1024 * 1024) {
           const dataUri = await toDataUri(localUri).catch(() => undefined);
           if (dataUri) {
-            setHtmlAttribute(parsed.attributes, 'src', dataUri);
+            setHtmlAttribute(
+              parsed.attributes,
+              'src',
+              withSvgFragment(dataUri, localUri)
+            );
             changed = true;
           }
         }
@@ -1807,7 +1818,7 @@ export class PreviewController implements vscode.Disposable {
 
             changed = true;
             return {
-              url: dataUri,
+              url: withSvgFragment(dataUri, localUri),
               descriptor: candidate.descriptor
             };
           })

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -12,6 +12,14 @@ import type {
   WebviewToExtensionMessage
 } from '../messaging/protocol';
 import { parseWebviewMessage } from '../messaging/validate';
+import {
+  getHtmlAttribute,
+  mapHtmlImgTags,
+  mapHtmlImgTagsAsync,
+  parseHtmlImgTag,
+  serializeHtmlImgTag,
+  setHtmlAttribute
+} from './htmlImageTags';
 import { renderMarkdown } from './markdown/markdownPipeline';
 import {
   fileSizeBytes,
@@ -70,38 +78,6 @@ interface CustomCssCommandChoice {
   workspaceFolder?: vscode.WorkspaceFolder;
   clear?: boolean;
   value?: boolean;
-}
-
-function escapeHtmlAttribute(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-function readImgAttribute(tag: string, name: string): string | undefined {
-  const pattern = new RegExp(
-    `\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\\\`]+))`,
-    'i'
-  );
-  const match = pattern.exec(tag);
-  return match?.[1] ?? match?.[2] ?? match?.[3];
-}
-
-function replaceImgAttribute(
-  tag: string,
-  name: string,
-  value: string
-): string {
-  const pattern = new RegExp(
-    `(\\b${name}\\s*=\\s*)(?:"[^"]*"|'[^']*'|[^\\s"'=<>\\\`]+)`,
-    'i'
-  );
-  return tag.replace(
-    pattern,
-    `$1"${escapeHtmlAttribute(value)}"`
-  );
 }
 
 function getSettings(resource?: vscode.Uri): RuntimeSettings {
@@ -1781,30 +1757,49 @@ export class PreviewController implements vscode.Disposable {
     html: string,
     maxImageMB: number
   ): Promise<string> {
-    const tags = [...html.matchAll(/<img\b[^>]*>/gi)];
-    let next = html;
-    for (const [tag] of tags) {
-      const localSrc = readImgAttribute(tag, 'data-local-src');
-      const currentSrc = readImgAttribute(tag, 'src');
-      if (!localSrc || !currentSrc) continue;
-      const localUri = vscode.Uri.parse(localSrc, true);
-      const bytes = await fileSizeBytes(localUri).catch(() => 0);
-      if (bytes <= 0 || bytes > maxImageMB * 1024 * 1024) continue;
-      const dataUri = await toDataUri(localUri).catch(() => undefined);
-      if (!dataUri) continue;
-      next = next.replace(tag, replaceImgAttribute(tag, 'src', dataUri));
-    }
-    return next;
-  }
+    return mapHtmlImgTagsAsync(html, async (tag) => {
+      const parsed = parseHtmlImgTag(tag);
+      if (!parsed) {
+        return tag;
+      }
 
-  private rewriteLocalImageSourcesForExport(html: string): string {
-    return html.replace(/<img\b[^>]*>/gi, (tag) => {
-      const localSrc = readImgAttribute(tag, 'data-local-src');
-      const currentSrc = readImgAttribute(tag, 'src');
+      const localSrc = getHtmlAttribute(parsed.attributes, 'data-local-src')
+        ?.value;
+      const currentSrc = getHtmlAttribute(parsed.attributes, 'src')?.value;
       if (!localSrc || !currentSrc) {
         return tag;
       }
-      return replaceImgAttribute(tag, 'src', localSrc);
+      const localUri = vscode.Uri.parse(localSrc, true);
+      const bytes = await fileSizeBytes(localUri).catch(() => 0);
+      if (bytes <= 0 || bytes > maxImageMB * 1024 * 1024) {
+        return tag;
+      }
+      const dataUri = await toDataUri(localUri).catch(() => undefined);
+      if (!dataUri) {
+        return tag;
+      }
+
+      setHtmlAttribute(parsed.attributes, 'src', dataUri);
+      return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
+    });
+  }
+
+  private rewriteLocalImageSourcesForExport(html: string): string {
+    return mapHtmlImgTags(html, (tag) => {
+      const parsed = parseHtmlImgTag(tag);
+      if (!parsed) {
+        return tag;
+      }
+
+      const localSrc = getHtmlAttribute(parsed.attributes, 'data-local-src')
+        ?.value;
+      const currentSrc = getHtmlAttribute(parsed.attributes, 'src')?.value;
+      if (!localSrc || !currentSrc) {
+        return tag;
+      }
+
+      setHtmlAttribute(parsed.attributes, 'src', localSrc);
+      return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
     });
   }
 

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -72,6 +72,38 @@ interface CustomCssCommandChoice {
   value?: boolean;
 }
 
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function readImgAttribute(tag: string, name: string): string | undefined {
+  const pattern = new RegExp(
+    `\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\\\`]+))`,
+    'i'
+  );
+  const match = pattern.exec(tag);
+  return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+function replaceImgAttribute(
+  tag: string,
+  name: string,
+  value: string
+): string {
+  const pattern = new RegExp(
+    `(\\b${name}\\s*=\\s*)(?:"[^"]*"|'[^']*'|[^\\s"'=<>\\\`]+)`,
+    'i'
+  );
+  return tag.replace(
+    pattern,
+    `$1"${escapeHtmlAttribute(value)}"`
+  );
+}
+
 function getSettings(resource?: vscode.Uri): RuntimeSettings {
   const cfg = vscode.workspace.getConfiguration(
     'offlineMarkdownViewer',
@@ -1749,34 +1781,31 @@ export class PreviewController implements vscode.Disposable {
     html: string,
     maxImageMB: number
   ): Promise<string> {
-    const matches = [
-      ...html.matchAll(
-        /<img[^>]*data-local-src="([^"]+)"[^>]*src="([^"]*)"[^>]*>/g
-      )
-    ];
+    const tags = [...html.matchAll(/<img\b[^>]*>/gi)];
     let next = html;
-    for (const match of matches) {
-      const localUri = vscode.Uri.parse(match[1], true);
+    for (const [tag] of tags) {
+      const localSrc = readImgAttribute(tag, 'data-local-src');
+      const currentSrc = readImgAttribute(tag, 'src');
+      if (!localSrc || !currentSrc) continue;
+      const localUri = vscode.Uri.parse(localSrc, true);
       const bytes = await fileSizeBytes(localUri).catch(() => 0);
       if (bytes <= 0 || bytes > maxImageMB * 1024 * 1024) continue;
       const dataUri = await toDataUri(localUri).catch(() => undefined);
       if (!dataUri) continue;
-      next = next.replace(match[2], dataUri);
+      next = next.replace(tag, replaceImgAttribute(tag, 'src', dataUri));
     }
     return next;
   }
 
   private rewriteLocalImageSourcesForExport(html: string): string {
-    return html.replace(
-      /(<img[^>]*data-local-src="([^"]+)"[^>]*src=")([^"]*)(")/g,
-      (
-        _match,
-        prefix: string,
-        localSrc: string,
-        _currentSrc: string,
-        suffix: string
-      ) => `${prefix}${localSrc}${suffix}`
-    );
+    return html.replace(/<img\b[^>]*>/gi, (tag) => {
+      const localSrc = readImgAttribute(tag, 'data-local-src');
+      const currentSrc = readImgAttribute(tag, 'src');
+      if (!localSrc || !currentSrc) {
+        return tag;
+      }
+      return replaceImgAttribute(tag, 'src', localSrc);
+    });
   }
 
   private async tryHeadlessPdfExport(

--- a/src/extension/preview/PreviewPanel.ts
+++ b/src/extension/preview/PreviewPanel.ts
@@ -17,7 +17,9 @@ import {
   mapHtmlImgTags,
   mapHtmlImgTagsAsync,
   parseHtmlImgTag,
+  parseHtmlSrcset,
   serializeHtmlImgTag,
+  serializeHtmlSrcset,
   setHtmlAttribute
 } from './htmlImageTags';
 import { renderMarkdown } from './markdown/markdownPipeline';
@@ -1765,21 +1767,56 @@ export class PreviewController implements vscode.Disposable {
 
       const localSrc = getHtmlAttribute(parsed.attributes, 'data-local-src')
         ?.value;
-      const currentSrc = getHtmlAttribute(parsed.attributes, 'src')?.value;
-      if (!localSrc || !currentSrc) {
-        return tag;
-      }
-      const localUri = vscode.Uri.parse(localSrc, true);
-      const bytes = await fileSizeBytes(localUri).catch(() => 0);
-      if (bytes <= 0 || bytes > maxImageMB * 1024 * 1024) {
-        return tag;
-      }
-      const dataUri = await toDataUri(localUri).catch(() => undefined);
-      if (!dataUri) {
-        return tag;
+      const exportSrcset = getHtmlAttribute(parsed.attributes, 'srcset')?.value;
+      let changed = false;
+
+      if (localSrc) {
+        const localUri = vscode.Uri.parse(localSrc, true);
+        const bytes = await fileSizeBytes(localUri).catch(() => 0);
+        if (bytes > 0 && bytes <= maxImageMB * 1024 * 1024) {
+          const dataUri = await toDataUri(localUri).catch(() => undefined);
+          if (dataUri) {
+            setHtmlAttribute(parsed.attributes, 'src', dataUri);
+            changed = true;
+          }
+        }
       }
 
-      setHtmlAttribute(parsed.attributes, 'src', dataUri);
+      if (exportSrcset) {
+        const embeddedSrcset = await Promise.all(
+          parseHtmlSrcset(exportSrcset).map(async (candidate) => {
+            if (!/^file:/i.test(candidate.url)) {
+              return candidate;
+            }
+
+            const localUri = vscode.Uri.parse(candidate.url, true);
+            const bytes = await fileSizeBytes(localUri).catch(() => 0);
+            if (bytes <= 0 || bytes > maxImageMB * 1024 * 1024) {
+              return candidate;
+            }
+
+            const dataUri = await toDataUri(localUri).catch(() => undefined);
+            if (!dataUri) {
+              return candidate;
+            }
+
+            changed = true;
+            return {
+              url: dataUri,
+              descriptor: candidate.descriptor
+            };
+          })
+        );
+        setHtmlAttribute(
+          parsed.attributes,
+          'srcset',
+          serializeHtmlSrcset(embeddedSrcset)
+        );
+      }
+
+      if (!changed) {
+        return tag;
+      }
       return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
     });
   }
@@ -1793,12 +1830,20 @@ export class PreviewController implements vscode.Disposable {
 
       const localSrc = getHtmlAttribute(parsed.attributes, 'data-local-src')
         ?.value;
-      const currentSrc = getHtmlAttribute(parsed.attributes, 'src')?.value;
-      if (!localSrc || !currentSrc) {
+      const exportSrcset = getHtmlAttribute(
+        parsed.attributes,
+        'data-export-srcset'
+      )?.value;
+      if (!localSrc && !exportSrcset) {
         return tag;
       }
 
-      setHtmlAttribute(parsed.attributes, 'src', localSrc);
+      if (localSrc) {
+        setHtmlAttribute(parsed.attributes, 'src', localSrc);
+      }
+      if (exportSrcset) {
+        setHtmlAttribute(parsed.attributes, 'srcset', exportSrcset);
+      }
       return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
     });
   }

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -288,8 +288,7 @@ export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
 
     while (
       index < value.length &&
-      !/\s/.test(value[index]) &&
-      value[index] !== ','
+      !/\s/.test(value[index])
     ) {
       index += 1;
     }
@@ -302,12 +301,6 @@ export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
       continue;
     }
 
-    if (!isDataUrl && value[index] === ',') {
-      candidates.push({ url });
-      index += 1;
-      continue;
-    }
-
     while (index < value.length && value[index] !== ',') {
       index += 1;
     }
@@ -317,7 +310,6 @@ export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
       .trim();
 
     if (
-      isDataUrl &&
       url.endsWith(',') &&
       descriptor &&
       !isValidSrcsetDescriptorSequence(descriptor)

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -298,6 +298,48 @@ function findHtmlImgTagEnd(html: string, fromIndex: number): number {
   return -1;
 }
 
+function findTagEnd(html: string, fromIndex: number): number {
+  let quote: '"' | "'" | undefined;
+
+  for (let index = fromIndex; index < html.length; index += 1) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === '>') {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function getLiteralContentTagName(tag: string): string | undefined {
+  const match = /^<([a-z0-9:-]+)/i.exec(tag);
+  if (!match) {
+    return undefined;
+  }
+
+  switch (match[1].toLowerCase()) {
+    case 'script':
+    case 'style':
+    case 'textarea':
+    case 'title':
+      return match[1];
+    default:
+      return undefined;
+  }
+}
+
 function findHtmlImgTagStart(html: string, fromIndex: number): number {
   let insideTag = false;
   let quote: '"' | "'" | undefined;
@@ -326,6 +368,23 @@ function findHtmlImgTagStart(html: string, fromIndex: number): number {
 
     if (/^<img\b/i.test(html.slice(index))) {
       return index;
+    }
+
+    const tagEnd = findTagEnd(html, index + 1);
+    if (tagEnd < 0) {
+      return -1;
+    }
+
+    const tag = html.slice(index, tagEnd + 1);
+    const literalTagName = getLiteralContentTagName(tag);
+    if (literalTagName) {
+      const closePattern = new RegExp(`</${literalTagName}\\s*>`, 'i');
+      const closeIndex = html.slice(tagEnd + 1).search(closePattern);
+      if (closeIndex < 0) {
+        return -1;
+      }
+      index = tagEnd + closeIndex + literalTagName.length + 3;
+      continue;
     }
 
     insideTag = true;

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -6,6 +6,11 @@ export interface HtmlAttribute {
   changed?: boolean;
 }
 
+export interface HtmlSrcsetCandidate {
+  url: string;
+  descriptor?: string;
+}
+
 function escapeHtmlAttribute(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -145,6 +150,57 @@ export function getHtmlAttribute(
   return attributes.find(
     (attr) => attr.name.toLowerCase() === name.toLowerCase()
   );
+}
+
+export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
+  const candidates: HtmlSrcsetCandidate[] = [];
+  let index = 0;
+
+  while (index < value.length) {
+    while (index < value.length && /[\s,]/.test(value[index])) {
+      index += 1;
+    }
+    if (index >= value.length) {
+      break;
+    }
+
+    const urlStart = index;
+    while (index < value.length && !/[\s,]/.test(value[index])) {
+      index += 1;
+    }
+
+    const url = value.slice(urlStart, index);
+    const descriptorStart = index;
+    while (index < value.length && value[index] !== ',') {
+      index += 1;
+    }
+
+    const descriptor = value.slice(descriptorStart, index).trim();
+    if (url) {
+      candidates.push({
+        url,
+        descriptor: descriptor || undefined
+      });
+    }
+
+    if (value[index] === ',') {
+      index += 1;
+    }
+  }
+
+  return candidates;
+}
+
+export function serializeHtmlSrcset(
+  candidates: HtmlSrcsetCandidate[]
+): string {
+  return candidates
+    .map((candidate) =>
+      candidate.descriptor
+        ? `${candidate.url} ${candidate.descriptor}`
+        : candidate.url
+    )
+    .join(', ');
 }
 
 function findHtmlImgTagEnd(html: string, fromIndex: number): number {

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -223,6 +223,11 @@ function findImplicitSrcsetCandidateSplit(
     return -1;
   }
 
+  const normalizedUrl = url.trim();
+  const requiresAbsoluteRightCandidate = /^(?:https?:|file:)/i.test(
+    normalizedUrl
+  );
+
   for (let index = 0; index < url.length; index += 1) {
     if (url[index] !== ',') {
       continue;
@@ -235,6 +240,12 @@ function findImplicitSrcsetCandidateSplit(
       looksLikeStandaloneSrcsetUrl(left) &&
       looksLikeStandaloneSrcsetUrl(rightSegment)
     ) {
+      if (
+        requiresAbsoluteRightCandidate &&
+        !/^(?:https?:|file:)/i.test(rightSegment.trim())
+      ) {
+        continue;
+      }
       return index;
     }
   }

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -75,12 +75,14 @@ export function parseHtmlImgTag(tag: string): {
     return null;
   }
 
-  const body = tag.replace(/^<img\b/i, '').replace(/\s*\/?>$/, '');
+  const body = tag.replace(/^<img\b/i, '').replace(/\s*>$/, '');
   const attributes: HtmlAttribute[] = [];
   const attrPattern =
     /([^\s"'=<>`/]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+  let lastMatchEnd = 0;
 
   for (const match of body.matchAll(attrPattern)) {
+    lastMatchEnd = (match.index ?? 0) + match[0].length;
     const name = match[1];
     const quote = match[2] !== undefined ? '"' : match[3] !== undefined ? "'" : undefined;
     const originalValue = match[2] ?? match[3] ?? match[4];
@@ -95,9 +97,10 @@ export function parseHtmlImgTag(tag: string): {
     );
   }
 
+  const trailing = body.slice(lastMatchEnd).trim();
   return {
     attributes,
-    selfClosing: /\/\s*>$/.test(tag)
+    selfClosing: trailing === '/'
   };
 }
 
@@ -494,6 +497,46 @@ function getLiteralContentTagName(tag: string): string | undefined {
   }
 }
 
+function findTemplateTagClose(html: string, fromIndex: number): number {
+  let depth = 1;
+
+  for (let index = fromIndex; index < html.length; index += 1) {
+    const nextTagStart = html.indexOf('<', index);
+    if (nextTagStart < 0) {
+      return -1;
+    }
+    index = nextTagStart;
+
+    if (html.startsWith('<!--', index)) {
+      const commentEnd = html.indexOf('-->', index + 4);
+      if (commentEnd < 0) {
+        return -1;
+      }
+      index = commentEnd + 2;
+      continue;
+    }
+
+    const nextTagEnd = findTagEnd(html, index + 1);
+    if (nextTagEnd < 0) {
+      return -1;
+    }
+
+    const nextTag = html.slice(index, nextTagEnd + 1);
+    if (/^<template\b/i.test(nextTag) && !/\/\s*>$/.test(nextTag)) {
+      depth += 1;
+    } else if (/^<\/template\s*>/i.test(nextTag)) {
+      depth -= 1;
+      if (depth === 0) {
+        return nextTagEnd;
+      }
+    }
+
+    index = nextTagEnd;
+  }
+
+  return -1;
+}
+
 function findHtmlImgTagStart(html: string, fromIndex: number): number {
   let insideTag = false;
   let quote: '"' | "'" | undefined;
@@ -541,6 +584,15 @@ function findHtmlImgTagStart(html: string, fromIndex: number): number {
     const tag = html.slice(index, tagEnd + 1);
     const literalTagName = getLiteralContentTagName(tag);
     if (literalTagName) {
+      if (literalTagName.toLowerCase() === 'template') {
+        const closeTagEnd = findTemplateTagClose(html, tagEnd + 1);
+        if (closeTagEnd < 0) {
+          return -1;
+        }
+        index = closeTagEnd;
+        continue;
+      }
+
       const closePattern = new RegExp(`</${literalTagName}\\s*>`, 'i');
       const closeIndex = html.slice(tagEnd + 1).search(closePattern);
       if (closeIndex < 0) {

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -486,6 +486,15 @@ function findHtmlImgTagStart(html: string, fromIndex: number): number {
       continue;
     }
 
+    if (html.startsWith('<!--', index)) {
+      const commentEnd = html.indexOf('-->', index + 4);
+      if (commentEnd < 0) {
+        return -1;
+      }
+      index = commentEnd + 2;
+      continue;
+    }
+
     if (/^<img\b/i.test(html.slice(index))) {
       return index;
     }

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -199,17 +199,44 @@ function looksLikeSrcsetUrlStart(value: string): boolean {
     return false;
   }
 
-  return !/[<>"'=]/.test(match[1]);
+  return !/[<>"']/.test(match[1]);
+}
+
+function getExplicitSrcsetUrlKind(
+  value: string
+): 'absolute-url' | 'protocol-relative' | 'root-relative' | 'dot-relative' | undefined {
+  const trimmed = value.trim();
+  if (!trimmed || /[\s,]/.test(trimmed) || /[<>"']/.test(trimmed)) {
+    return undefined;
+  }
+
+  if (/^(?:https?:|file:)/i.test(trimmed)) {
+    return 'absolute-url';
+  }
+
+  if (/^\/\//.test(trimmed)) {
+    return 'protocol-relative';
+  }
+
+  if (/^\//.test(trimmed)) {
+    return 'root-relative';
+  }
+
+  if (/^\.\.?\//.test(trimmed)) {
+    return 'dot-relative';
+  }
+
+  return undefined;
 }
 
 function looksLikeStandaloneSrcsetUrl(value: string): boolean {
   const trimmed = value.trim();
-  if (!trimmed || /[\s,]/.test(trimmed)) {
+  if (!trimmed || /[\s,]/.test(trimmed) || /[<>"']/.test(trimmed)) {
     return false;
   }
 
   return (
-    /^(?:https?:|file:)/i.test(trimmed) ||
+    getExplicitSrcsetUrlKind(trimmed) !== undefined ||
     /^[^/?#,\s]+\.[a-z0-9]{1,8}(?:[?#][^,\s]*)?$/i.test(trimmed) ||
     /\/[^/?#,\s]+\.[a-z0-9]{1,8}(?:[?#][^,\s]*)?$/i.test(trimmed)
   );
@@ -223,11 +250,6 @@ function findImplicitSrcsetCandidateSplit(
     return -1;
   }
 
-  const normalizedUrl = url.trim();
-  const requiresAbsoluteRightCandidate = /^(?:https?:|file:)/i.test(
-    normalizedUrl
-  );
-
   for (let index = 0; index < url.length; index += 1) {
     if (url[index] !== ',') {
       continue;
@@ -236,13 +258,14 @@ function findImplicitSrcsetCandidateSplit(
     const left = url.slice(0, index);
     const right = url.slice(index + 1);
     const rightSegment = right.split(',')[0] ?? '';
+    const leftKind = getExplicitSrcsetUrlKind(left);
     if (
       looksLikeStandaloneSrcsetUrl(left) &&
       looksLikeStandaloneSrcsetUrl(rightSegment)
     ) {
       if (
-        requiresAbsoluteRightCandidate &&
-        !/^(?:https?:|file:)/i.test(rightSegment.trim())
+        leftKind &&
+        getExplicitSrcsetUrlKind(rightSegment.trim()) !== leftKind
       ) {
         continue;
       }

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -152,6 +152,47 @@ export function getHtmlAttribute(
   );
 }
 
+function isValidSrcsetDescriptorSequence(value: string): boolean {
+  const tokens = value.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  let sawDensity = false;
+  let sawWidth = false;
+  let sawHeight = false;
+
+  for (const token of tokens) {
+    if (/^\d+w$/i.test(token)) {
+      if (sawDensity || sawWidth) {
+        return false;
+      }
+      sawWidth = true;
+      continue;
+    }
+
+    if (/^\d+h$/i.test(token)) {
+      if (sawDensity || sawHeight) {
+        return false;
+      }
+      sawHeight = true;
+      continue;
+    }
+
+    if (/^(?:\d+|\d*\.\d+)x$/i.test(token)) {
+      if (sawDensity || sawWidth || sawHeight) {
+        return false;
+      }
+      sawDensity = true;
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
 export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
   const candidates: HtmlSrcsetCandidate[] = [];
   let index = 0;
@@ -165,23 +206,53 @@ export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
     }
 
     const urlStart = index;
-    while (index < value.length && !/[\s,]/.test(value[index])) {
+    const isDataUrl = /^data:/i.test(value.slice(index));
+    while (
+      index < value.length &&
+      !/\s/.test(value[index]) &&
+      (isDataUrl || value[index] !== ',')
+    ) {
       index += 1;
     }
 
-    const url = value.slice(urlStart, index);
-    const descriptorStart = index;
+    let url = value.slice(urlStart, index);
+    if (!url) {
+      if (value[index] === ',') {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (!isDataUrl && value[index] === ',') {
+      candidates.push({ url });
+      index += 1;
+      continue;
+    }
+
     while (index < value.length && value[index] !== ',') {
       index += 1;
     }
+    const descriptorEnd = index;
+    const descriptor = value
+      .slice(url.length + urlStart, descriptorEnd)
+      .trim();
 
-    const descriptor = value.slice(descriptorStart, index).trim();
-    if (url) {
-      candidates.push({
-        url,
-        descriptor: descriptor || undefined
-      });
+    if (
+      isDataUrl &&
+      url.endsWith(',') &&
+      descriptor &&
+      !isValidSrcsetDescriptorSequence(descriptor)
+    ) {
+      url = url.slice(0, -1);
+      index = urlStart + url.length + 1;
+      candidates.push({ url });
+      continue;
     }
+
+    candidates.push({
+      url,
+      descriptor: descriptor || undefined
+    });
 
     if (value[index] === ',') {
       index += 1;

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -1,6 +1,9 @@
 export interface HtmlAttribute {
   name: string;
   value?: string;
+  originalValue?: string;
+  quote?: '"' | "'";
+  changed?: boolean;
 }
 
 function escapeHtmlAttribute(value: string): string {
@@ -9,6 +12,54 @@ function escapeHtmlAttribute(value: string): string {
     .replace(/"/g, '&quot;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+}
+
+function decodeHtmlAttribute(value: string): string {
+  const decodeCodePoint = (codePoint: number, raw: string): string => {
+    if (
+      Number.isNaN(codePoint) ||
+      codePoint < 0 ||
+      codePoint > 0x10ffff
+    ) {
+      return raw;
+    }
+
+    try {
+      return String.fromCodePoint(codePoint);
+    } catch {
+      return raw;
+    }
+  };
+
+  return value.replace(
+    /&(?:#(\d+)|#x([0-9a-fA-F]+)|amp|quot|apos|lt|gt);/g,
+    (match, numeric, hex) => {
+      if (numeric) {
+        const codePoint = Number.parseInt(numeric, 10);
+        return decodeCodePoint(codePoint, match);
+      }
+
+      if (hex) {
+        const codePoint = Number.parseInt(hex, 16);
+        return decodeCodePoint(codePoint, match);
+      }
+
+      switch (match) {
+        case '&amp;':
+          return '&';
+        case '&quot;':
+          return '"';
+        case '&apos;':
+          return "'";
+        case '&lt;':
+          return '<';
+        case '&gt;':
+          return '>';
+        default:
+          return match;
+      }
+    }
+  );
 }
 
 export function parseHtmlImgTag(tag: string): {
@@ -26,8 +77,17 @@ export function parseHtmlImgTag(tag: string): {
 
   for (const match of body.matchAll(attrPattern)) {
     const name = match[1];
-    const value = match[2] ?? match[3] ?? match[4];
-    attributes.push(value === undefined ? { name } : { name, value });
+    const quote = match[2] !== undefined ? '"' : match[3] !== undefined ? "'" : undefined;
+    const originalValue = match[2] ?? match[3] ?? match[4];
+    const value =
+      originalValue === undefined
+        ? undefined
+        : decodeHtmlAttribute(originalValue);
+    attributes.push(
+      value === undefined
+        ? { name }
+        : { name, value, originalValue, quote, changed: false }
+    );
   }
 
   return {
@@ -41,11 +101,20 @@ export function serializeHtmlImgTag(
   selfClosing: boolean
 ): string {
   const renderedAttrs = attributes
-    .map((attr) =>
-      attr.value === undefined
-        ? ` ${attr.name}`
-        : ` ${attr.name}="${escapeHtmlAttribute(attr.value)}"`
-    )
+    .map((attr) => {
+      if (attr.value === undefined) {
+        return ` ${attr.name}`;
+      }
+
+      if (!attr.changed && attr.originalValue !== undefined) {
+        if (attr.quote) {
+          return ` ${attr.name}=${attr.quote}${attr.originalValue}${attr.quote}`;
+        }
+        return ` ${attr.name}=${attr.originalValue}`;
+      }
+
+      return ` ${attr.name}="${escapeHtmlAttribute(attr.value)}"`;
+    })
     .join('');
   return `<img${renderedAttrs}${selfClosing ? ' />' : '>'}`;
 }
@@ -61,9 +130,12 @@ export function setHtmlAttribute(
   if (existing) {
     existing.name = name;
     existing.value = value;
+    existing.originalValue = undefined;
+    existing.quote = undefined;
+    existing.changed = true;
     return;
   }
-  attributes.push({ name, value });
+  attributes.push({ name, value, changed: true });
 }
 
 export function getHtmlAttribute(
@@ -99,18 +171,52 @@ function findHtmlImgTagEnd(html: string, fromIndex: number): number {
   return -1;
 }
 
+function findHtmlImgTagStart(html: string, fromIndex: number): number {
+  let insideTag = false;
+  let quote: '"' | "'" | undefined;
+
+  for (let index = fromIndex; index < html.length; index += 1) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (insideTag) {
+      if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === '>') {
+        insideTag = false;
+      }
+      continue;
+    }
+
+    if (char !== '<') {
+      continue;
+    }
+
+    if (/^<img\b/i.test(html.slice(index))) {
+      return index;
+    }
+
+    insideTag = true;
+  }
+
+  return -1;
+}
+
 function mapHtmlImgTagsInternal<T extends string | Promise<string>>(
   html: string,
   transform: (tag: string) => T
 ): T | string {
-  const startPattern = /<img\b/gi;
   let nextIndex = 0;
   let result = '';
-  let match: RegExpExecArray | null;
+  let start = findHtmlImgTagStart(html, nextIndex);
 
-  while ((match = startPattern.exec(html))) {
-    const start = match.index;
-    const end = findHtmlImgTagEnd(html, startPattern.lastIndex);
+  while (start >= 0) {
+    const end = findHtmlImgTagEnd(html, start + 4);
     if (end < 0) {
       break;
     }
@@ -121,17 +227,16 @@ function mapHtmlImgTagsInternal<T extends string | Promise<string>>(
     const mapped = transform(tag);
     if (typeof mapped === 'string') {
       result += mapped;
-      startPattern.lastIndex = nextIndex;
+      start = findHtmlImgTagStart(html, nextIndex);
       continue;
     }
 
     return (async () => {
       let asyncResult = result + (await mapped);
-      startPattern.lastIndex = nextIndex;
+      let asyncStart = findHtmlImgTagStart(html, nextIndex);
 
-      while ((match = startPattern.exec(html))) {
-        const asyncStart = match.index;
-        const asyncEnd = findHtmlImgTagEnd(html, startPattern.lastIndex);
+      while (asyncStart >= 0) {
+        const asyncEnd = findHtmlImgTagEnd(html, asyncStart + 4);
         if (asyncEnd < 0) {
           break;
         }
@@ -140,7 +245,7 @@ function mapHtmlImgTagsInternal<T extends string | Promise<string>>(
         nextIndex = asyncEnd + 1;
         const asyncTag = html.slice(asyncStart, nextIndex);
         asyncResult += await transform(asyncTag);
-        startPattern.lastIndex = nextIndex;
+        asyncStart = findHtmlImgTagStart(html, nextIndex);
       }
 
       return asyncResult + html.slice(nextIndex);

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -1,0 +1,165 @@
+export interface HtmlAttribute {
+  name: string;
+  value?: string;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function parseHtmlImgTag(tag: string): {
+  attributes: HtmlAttribute[];
+  selfClosing: boolean;
+} | null {
+  if (!/^<img\b/i.test(tag)) {
+    return null;
+  }
+
+  const body = tag.replace(/^<img\b/i, '').replace(/\s*\/?>$/, '');
+  const attributes: HtmlAttribute[] = [];
+  const attrPattern =
+    /([^\s"'=<>`/]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+  for (const match of body.matchAll(attrPattern)) {
+    const name = match[1];
+    const value = match[2] ?? match[3] ?? match[4];
+    attributes.push(value === undefined ? { name } : { name, value });
+  }
+
+  return {
+    attributes,
+    selfClosing: /\/\s*>$/.test(tag)
+  };
+}
+
+export function serializeHtmlImgTag(
+  attributes: HtmlAttribute[],
+  selfClosing: boolean
+): string {
+  const renderedAttrs = attributes
+    .map((attr) =>
+      attr.value === undefined
+        ? ` ${attr.name}`
+        : ` ${attr.name}="${escapeHtmlAttribute(attr.value)}"`
+    )
+    .join('');
+  return `<img${renderedAttrs}${selfClosing ? ' />' : '>'}`;
+}
+
+export function setHtmlAttribute(
+  attributes: HtmlAttribute[],
+  name: string,
+  value: string
+): void {
+  const existing = attributes.find(
+    (attr) => attr.name.toLowerCase() === name.toLowerCase()
+  );
+  if (existing) {
+    existing.name = name;
+    existing.value = value;
+    return;
+  }
+  attributes.push({ name, value });
+}
+
+export function getHtmlAttribute(
+  attributes: HtmlAttribute[],
+  name: string
+): HtmlAttribute | undefined {
+  return attributes.find(
+    (attr) => attr.name.toLowerCase() === name.toLowerCase()
+  );
+}
+
+function findHtmlImgTagEnd(html: string, fromIndex: number): number {
+  let quote: '"' | "'" | undefined;
+  for (let index = fromIndex; index < html.length; index += 1) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === '>') {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function mapHtmlImgTagsInternal<T extends string | Promise<string>>(
+  html: string,
+  transform: (tag: string) => T
+): T | string {
+  const startPattern = /<img\b/gi;
+  let nextIndex = 0;
+  let result = '';
+  let match: RegExpExecArray | null;
+
+  while ((match = startPattern.exec(html))) {
+    const start = match.index;
+    const end = findHtmlImgTagEnd(html, startPattern.lastIndex);
+    if (end < 0) {
+      break;
+    }
+
+    result += html.slice(nextIndex, start);
+    nextIndex = end + 1;
+    const tag = html.slice(start, nextIndex);
+    const mapped = transform(tag);
+    if (typeof mapped === 'string') {
+      result += mapped;
+      startPattern.lastIndex = nextIndex;
+      continue;
+    }
+
+    return (async () => {
+      let asyncResult = result + (await mapped);
+      startPattern.lastIndex = nextIndex;
+
+      while ((match = startPattern.exec(html))) {
+        const asyncStart = match.index;
+        const asyncEnd = findHtmlImgTagEnd(html, startPattern.lastIndex);
+        if (asyncEnd < 0) {
+          break;
+        }
+
+        asyncResult += html.slice(nextIndex, asyncStart);
+        nextIndex = asyncEnd + 1;
+        const asyncTag = html.slice(asyncStart, nextIndex);
+        asyncResult += await transform(asyncTag);
+        startPattern.lastIndex = nextIndex;
+      }
+
+      return asyncResult + html.slice(nextIndex);
+    })() as T;
+  }
+
+  return result + html.slice(nextIndex);
+}
+
+export function mapHtmlImgTags(
+  html: string,
+  transform: (tag: string) => string
+): string {
+  return mapHtmlImgTagsInternal(html, transform);
+}
+
+export async function mapHtmlImgTagsAsync(
+  html: string,
+  transform: (tag: string) => Promise<string>
+): Promise<string> {
+  return mapHtmlImgTagsInternal(html, transform);
+}

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -193,6 +193,78 @@ function isValidSrcsetDescriptorSequence(value: string): boolean {
   return true;
 }
 
+function looksLikeSrcsetUrlStart(value: string): boolean {
+  const match = /^\s*([^,\s]+)/.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  return !/[<>"'=]/.test(match[1]);
+}
+
+function parseDataSrcsetCandidate(
+  value: string,
+  startIndex: number
+): { candidate: HtmlSrcsetCandidate; nextIndex: number } {
+  let index = startIndex;
+
+  while (index < value.length) {
+    while (
+      index < value.length &&
+      value[index] !== ',' &&
+      !/\s/.test(value[index])
+    ) {
+      index += 1;
+    }
+
+    if (index >= value.length) {
+      return {
+        candidate: { url: value.slice(startIndex).trim() },
+        nextIndex: value.length
+      };
+    }
+
+    if (!/\s/.test(value[index])) {
+      index += 1;
+      continue;
+    }
+
+    const descriptorStart = index;
+    while (index < value.length && value[index] !== ',') {
+      index += 1;
+    }
+
+    const descriptor = value.slice(descriptorStart, index).trim();
+    const url = value.slice(startIndex, descriptorStart).trimEnd();
+
+    if (descriptor && isValidSrcsetDescriptorSequence(descriptor)) {
+      return {
+        candidate: { url, descriptor },
+        nextIndex: value[index] === ',' ? index + 1 : index
+      };
+    }
+
+    if (
+      descriptor &&
+      url.endsWith(',') &&
+      looksLikeSrcsetUrlStart(descriptor)
+    ) {
+      const normalizedUrl = url.slice(0, -1);
+      return {
+        candidate: { url: normalizedUrl },
+        nextIndex: startIndex + normalizedUrl.length + 1
+      };
+    }
+
+    index = descriptorStart + 1;
+  }
+
+  return {
+    candidate: { url: value.slice(startIndex).trim() },
+    nextIndex: value.length
+  };
+}
+
 export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
   const candidates: HtmlSrcsetCandidate[] = [];
   let index = 0;
@@ -207,10 +279,17 @@ export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
 
     const urlStart = index;
     const isDataUrl = /^data:/i.test(value.slice(index));
+    if (isDataUrl) {
+      const parsed = parseDataSrcsetCandidate(value, urlStart);
+      candidates.push(parsed.candidate);
+      index = parsed.nextIndex;
+      continue;
+    }
+
     while (
       index < value.length &&
       !/\s/.test(value[index]) &&
-      (isDataUrl || value[index] !== ',')
+      value[index] !== ','
     ) {
       index += 1;
     }
@@ -332,8 +411,10 @@ function getLiteralContentTagName(tag: string): string | undefined {
   switch (match[1].toLowerCase()) {
     case 'script':
     case 'style':
+    case 'template':
     case 'textarea':
     case 'title':
+    case 'noscript':
       return match[1];
     default:
       return undefined;

--- a/src/extension/preview/htmlImageTags.ts
+++ b/src/extension/preview/htmlImageTags.ts
@@ -202,6 +202,46 @@ function looksLikeSrcsetUrlStart(value: string): boolean {
   return !/[<>"'=]/.test(match[1]);
 }
 
+function looksLikeStandaloneSrcsetUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || /[\s,]/.test(trimmed)) {
+    return false;
+  }
+
+  return (
+    /^(?:https?:|file:)/i.test(trimmed) ||
+    /^[^/?#,\s]+\.[a-z0-9]{1,8}(?:[?#][^,\s]*)?$/i.test(trimmed) ||
+    /\/[^/?#,\s]+\.[a-z0-9]{1,8}(?:[?#][^,\s]*)?$/i.test(trimmed)
+  );
+}
+
+function findImplicitSrcsetCandidateSplit(
+  url: string,
+  descriptor?: string
+): number {
+  if (!descriptor || !isValidSrcsetDescriptorSequence(descriptor)) {
+    return -1;
+  }
+
+  for (let index = 0; index < url.length; index += 1) {
+    if (url[index] !== ',') {
+      continue;
+    }
+
+    const left = url.slice(0, index);
+    const right = url.slice(index + 1);
+    const rightSegment = right.split(',')[0] ?? '';
+    if (
+      looksLikeStandaloneSrcsetUrl(left) &&
+      looksLikeStandaloneSrcsetUrl(rightSegment)
+    ) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
 function parseDataSrcsetCandidate(
   value: string,
   startIndex: number
@@ -308,6 +348,13 @@ export function parseHtmlSrcset(value: string): HtmlSrcsetCandidate[] {
     const descriptor = value
       .slice(url.length + urlStart, descriptorEnd)
       .trim();
+
+    const implicitSplit = findImplicitSrcsetCandidateSplit(url, descriptor);
+    if (implicitSplit >= 0) {
+      candidates.push({ url: url.slice(0, implicitSplit) });
+      index = urlStart + implicitSplit + 1;
+      continue;
+    }
 
     if (
       url.endsWith(',') &&

--- a/src/extension/preview/markdown/linkResolver.ts
+++ b/src/extension/preview/markdown/linkResolver.ts
@@ -76,17 +76,38 @@ export async function toDataUri(uri: vscode.Uri): Promise<string> {
   return `data:${mime};base64,${bytes.toString('base64')}`;
 }
 
+function stripLocalImageUrlDecoration(src: string): string {
+  const queryIndex = src.indexOf('?');
+  const hashIndex = src.indexOf('#');
+  const endIndex =
+    queryIndex >= 0 && hashIndex >= 0
+      ? Math.min(queryIndex, hashIndex)
+      : queryIndex >= 0
+        ? queryIndex
+        : hashIndex;
+  return endIndex >= 0 ? src.slice(0, endIndex) : src;
+}
+
 export function resolveImageUri(source: vscode.Uri, src: string): vscode.Uri | undefined {
-  if (!src || isHttpUrl(src) || /^data:/i.test(src) || /^vscode-webview-resource:/i.test(src)) {
+  const normalizedSrc = stripLocalImageUrlDecoration(src);
+  if (
+    !normalizedSrc ||
+    isHttpUrl(normalizedSrc) ||
+    /^data:/i.test(normalizedSrc) ||
+    /^vscode-webview-resource:/i.test(normalizedSrc)
+  ) {
     return undefined;
   }
   const sourceFolder = vscode.workspace.getWorkspaceFolder(source);
-  if (/^file:/i.test(src)) {
-    const parsed = vscode.Uri.parse(src, true);
+  if (/^file:/i.test(normalizedSrc)) {
+    const parsed = vscode.Uri.parse(normalizedSrc, true);
     if (!sourceFolder) return parsed;
     return isWithinWorkspace(parsed, sourceFolder.uri) ? parsed : undefined;
   }
-  const resolved = vscode.Uri.joinPath(source.with({ path: path.posix.dirname(source.path) }), src);
+  const resolved = vscode.Uri.joinPath(
+    source.with({ path: path.posix.dirname(source.path) }),
+    normalizedSrc
+  );
   if (!sourceFolder) return resolved;
   return isWithinWorkspace(resolved, sourceFolder.uri) ? resolved : undefined;
 }

--- a/src/extension/preview/markdown/linkResolver.ts
+++ b/src/extension/preview/markdown/linkResolver.ts
@@ -76,20 +76,33 @@ export async function toDataUri(uri: vscode.Uri): Promise<string> {
   return `data:${mime};base64,${bytes.toString('base64')}`;
 }
 
-function stripLocalImageUrlDecoration(src: string): string {
-  const queryIndex = src.indexOf('?');
+function stripLocalImageUrlDecoration(src: string): {
+  normalizedSrc: string;
+  fragment?: string;
+} {
   const hashIndex = src.indexOf('#');
-  const endIndex =
-    queryIndex >= 0 && hashIndex >= 0
-      ? Math.min(queryIndex, hashIndex)
-      : queryIndex >= 0
-        ? queryIndex
-        : hashIndex;
-  return endIndex >= 0 ? src.slice(0, endIndex) : src;
+  const beforeHash = hashIndex >= 0 ? src.slice(0, hashIndex) : src;
+  const queryIndex = beforeHash.indexOf('?');
+
+  return {
+    normalizedSrc:
+      queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash,
+    fragment: hashIndex >= 0 ? src.slice(hashIndex + 1) : undefined
+  };
+}
+
+function restoreSvgFragment(
+  uri: vscode.Uri,
+  fragment?: string
+): vscode.Uri {
+  if (!fragment || path.extname(uri.fsPath || uri.path).toLowerCase() !== '.svg') {
+    return uri;
+  }
+  return uri.with({ fragment });
 }
 
 export function resolveImageUri(source: vscode.Uri, src: string): vscode.Uri | undefined {
-  const normalizedSrc = stripLocalImageUrlDecoration(src);
+  const { normalizedSrc, fragment } = stripLocalImageUrlDecoration(src);
   if (
     !normalizedSrc ||
     isHttpUrl(normalizedSrc) ||
@@ -101,13 +114,15 @@ export function resolveImageUri(source: vscode.Uri, src: string): vscode.Uri | u
   const sourceFolder = vscode.workspace.getWorkspaceFolder(source);
   if (/^file:/i.test(normalizedSrc)) {
     const parsed = vscode.Uri.parse(normalizedSrc, true);
-    if (!sourceFolder) return parsed;
-    return isWithinWorkspace(parsed, sourceFolder.uri) ? parsed : undefined;
+    const resolved = restoreSvgFragment(parsed, fragment);
+    if (!sourceFolder) return resolved;
+    return isWithinWorkspace(parsed, sourceFolder.uri) ? resolved : undefined;
   }
-  const resolved = vscode.Uri.joinPath(
+  const resolvedBase = vscode.Uri.joinPath(
     source.with({ path: path.posix.dirname(source.path) }),
     normalizedSrc
   );
+  const resolved = restoreSvgFragment(resolvedBase, fragment);
   if (!sourceFolder) return resolved;
-  return isWithinWorkspace(resolved, sourceFolder.uri) ? resolved : undefined;
+  return isWithinWorkspace(resolvedBase, sourceFolder.uri) ? resolved : undefined;
 }

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -190,6 +190,7 @@ function rewriteImageAttributes(
       'src',
       options.webview.asWebviewUri(override).toString()
     );
+    rewriteSrcsetAttribute(attributes, options);
   } else if (resolved) {
     setHtmlAttribute(attributes, 'data-local-src', resolved.toString());
     try {
@@ -204,6 +205,7 @@ function rewriteImageAttributes(
         setHtmlAttribute(attributes, 'data-image-blocked', 'size-limit');
         setHtmlAttribute(attributes, 'src', '');
         setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
+        rewriteSrcsetAttribute(attributes, options);
       } else {
         setHtmlAttribute(
           attributes,
@@ -225,6 +227,7 @@ function rewriteImageAttributes(
     setHtmlAttribute(attributes, 'data-remote-src', rawSrc);
     setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
     setHtmlAttribute(attributes, 'src', '');
+    setHtmlAttribute(attributes, 'srcset', '');
   }
 
   setHtmlAttribute(attributes, 'loading', 'lazy');

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -183,6 +183,8 @@ function rewriteImageAttributes(
 ): void {
   const override = options.remoteImageOverrides?.get(rawSrc);
   const resolved = resolveImageUri(options.sourceUri, rawSrc);
+  const blockedRemoteImage =
+    /^https?:\/\//i.test(rawSrc) && !options.allowRemoteImages;
 
   if (override) {
     setHtmlAttribute(attributes, 'data-local-src', override.toString());
@@ -191,7 +193,6 @@ function rewriteImageAttributes(
       'src',
       options.webview.asWebviewUri(override).toString()
     );
-    rewriteSrcsetAttribute(attributes, options);
   } else if (resolved) {
     setHtmlAttribute(attributes, 'data-local-src', resolved.toString());
     try {
@@ -206,14 +207,12 @@ function rewriteImageAttributes(
         setHtmlAttribute(attributes, 'data-image-blocked', 'size-limit');
         setHtmlAttribute(attributes, 'src', '');
         setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
-        rewriteSrcsetAttribute(attributes, options);
       } else {
         setHtmlAttribute(
           attributes,
           'src',
           options.webview.asWebviewUri(resolved).toString()
         );
-        rewriteSrcsetAttribute(attributes, options);
       }
     } catch {
       // If stat fails we still rewrite to a webview URI and let runtime loading decide the result.
@@ -222,18 +221,18 @@ function rewriteImageAttributes(
         'src',
         options.webview.asWebviewUri(resolved).toString()
       );
-      rewriteSrcsetAttribute(attributes, options);
     }
-  } else if (/^https?:\/\//i.test(rawSrc) && !options.allowRemoteImages) {
+  } else if (blockedRemoteImage) {
     setHtmlAttribute(attributes, 'data-remote-src', rawSrc);
     setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
-    const srcset = getHtmlAttribute(attributes, 'srcset')?.value;
-    if (srcset) {
-      rewriteSrcsetAttribute(attributes, options);
-      const previewSrcset = getHtmlAttribute(attributes, 'srcset')?.value;
-      const previewSrc = previewSrcset
-        ? parseHtmlSrcset(previewSrcset)[0]?.url
-        : undefined;
+  }
+
+  rewriteSrcsetAttribute(attributes, options);
+
+  if (blockedRemoteImage) {
+    const previewSrcset = getHtmlAttribute(attributes, 'srcset')?.value;
+    if (previewSrcset) {
+      const previewSrc = parseHtmlSrcset(previewSrcset)[0]?.url;
       setHtmlAttribute(attributes, 'src', previewSrc ?? '');
     } else {
       setHtmlAttribute(attributes, 'srcset', '');

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -30,6 +30,11 @@ export interface MarkdownRenderResult {
   lineCount: number;
 }
 
+interface HtmlAttribute {
+  name: string;
+  value?: string;
+}
+
 function slugify(value: string): string {
   return value
     .trim()
@@ -85,6 +90,148 @@ function renderMathPlaceholder(
     return `<div class="${className}"${extraAttrs} data-math="${encodeMathExpression(expr)}"></div>`;
   }
   return `<span class="${className}"${extraAttrs} data-math="${encodeMathExpression(expr)}"></span>`;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function parseHtmlImgTag(tag: string): {
+  attributes: HtmlAttribute[];
+  selfClosing: boolean;
+} | null {
+  const body = tag.replace(/^<img\b/i, '').replace(/\s*\/?>$/, '');
+  const attributes: HtmlAttribute[] = [];
+  const attrPattern =
+    /([^\s"'=<>`\/]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+  for (const match of body.matchAll(attrPattern)) {
+    const name = match[1];
+    const value = match[2] ?? match[3] ?? match[4];
+    attributes.push(
+      value === undefined ? { name } : { name, value }
+    );
+  }
+
+  return {
+    attributes,
+    selfClosing: /\/\s*>$/.test(tag)
+  };
+}
+
+function serializeHtmlImgTag(
+  attributes: HtmlAttribute[],
+  selfClosing: boolean
+): string {
+  const renderedAttrs = attributes
+    .map((attr) =>
+      attr.value === undefined
+        ? ` ${attr.name}`
+        : ` ${attr.name}="${escapeHtmlAttribute(attr.value)}"`
+    )
+    .join('');
+  return `<img${renderedAttrs}${selfClosing ? ' />' : '>'}`;
+}
+
+function setHtmlAttribute(
+  attributes: HtmlAttribute[],
+  name: string,
+  value: string
+): void {
+  const existing = attributes.find(
+    (attr) => attr.name.toLowerCase() === name.toLowerCase()
+  );
+  if (existing) {
+    existing.name = name;
+    existing.value = value;
+    return;
+  }
+  attributes.push({ name, value });
+}
+
+function getHtmlAttribute(
+  attributes: HtmlAttribute[],
+  name: string
+): HtmlAttribute | undefined {
+  return attributes.find(
+    (attr) => attr.name.toLowerCase() === name.toLowerCase()
+  );
+}
+
+function rewriteImageAttributes(
+  attributes: HtmlAttribute[],
+  rawSrc: string,
+  options: MarkdownRenderOptions
+): void {
+  const override = options.remoteImageOverrides?.get(rawSrc);
+  const resolved = resolveImageUri(options.sourceUri, rawSrc);
+
+  if (override) {
+    setHtmlAttribute(attributes, 'data-local-src', override.toString());
+    setHtmlAttribute(
+      attributes,
+      'src',
+      options.webview.asWebviewUri(override).toString()
+    );
+  } else if (resolved) {
+    try {
+      const bytes = statSync(resolved.fsPath).size;
+      if (bytes > options.maxImageMB * 1024 * 1024) {
+        const alt = getHtmlAttribute(attributes, 'alt')?.value ?? 'image';
+        setHtmlAttribute(
+          attributes,
+          'alt',
+          `${alt} (blocked: exceeds preview.maxImageMB)`
+        );
+        setHtmlAttribute(attributes, 'data-image-blocked', 'size-limit');
+        setHtmlAttribute(attributes, 'src', '');
+        setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
+        return;
+      }
+    } catch {
+      // If stat fails we still rewrite to a webview URI and let runtime loading decide the result.
+    }
+
+    setHtmlAttribute(attributes, 'data-local-src', resolved.toString());
+    setHtmlAttribute(
+      attributes,
+      'src',
+      options.webview.asWebviewUri(resolved).toString()
+    );
+  } else if (/^https?:\/\//i.test(rawSrc) && !options.allowRemoteImages) {
+    setHtmlAttribute(attributes, 'data-remote-src', rawSrc);
+    setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
+    setHtmlAttribute(attributes, 'src', '');
+  }
+
+  setHtmlAttribute(attributes, 'loading', 'lazy');
+  setHtmlAttribute(attributes, 'decoding', 'async');
+  setHtmlAttribute(attributes, 'referrerpolicy', 'no-referrer');
+  setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
+}
+
+function rewriteRawHtmlImages(
+  html: string,
+  options: MarkdownRenderOptions
+): string {
+  return html.replace(/<img\b[^>]*>/gi, (tag) => {
+    const parsed = parseHtmlImgTag(tag);
+    if (!parsed) {
+      return tag;
+    }
+
+    const src = getHtmlAttribute(parsed.attributes, 'src')?.value;
+    if (!src) {
+      return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
+    }
+
+    rewriteImageAttributes(parsed.attributes, src, options);
+    return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
+  });
 }
 
 function isEscaped(source: string, index: number): boolean {
@@ -375,7 +522,7 @@ export function renderMarkdown(input: string, options: MarkdownRenderOptions): M
   const parsed = parseFrontmatter(input);
   const md = createMarkdownIt(options);
   const env: RenderEnvironment = { toc: [] };
-  const html = md.render(parsed.content, env);
+  const html = rewriteRawHtmlImages(md.render(parsed.content, env), options);
   const lineCount = input.split(/\r?\n/).length;
 
   return {

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -229,10 +229,16 @@ function rewriteImageAttributes(
     setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
     const srcset = getHtmlAttribute(attributes, 'srcset')?.value;
     if (srcset) {
-      setHtmlAttribute(attributes, 'data-export-srcset', srcset);
+      rewriteSrcsetAttribute(attributes, options);
+      const previewSrcset = getHtmlAttribute(attributes, 'srcset')?.value;
+      const previewSrc = previewSrcset
+        ? parseHtmlSrcset(previewSrcset)[0]?.url
+        : undefined;
+      setHtmlAttribute(attributes, 'src', previewSrc ?? '');
+    } else {
+      setHtmlAttribute(attributes, 'srcset', '');
+      setHtmlAttribute(attributes, 'src', '');
     }
-    setHtmlAttribute(attributes, 'src', '');
-    setHtmlAttribute(attributes, 'srcset', '');
   }
 
   setHtmlAttribute(attributes, 'loading', 'lazy');

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -151,6 +151,7 @@ function rewriteSrcsetAttribute(
     }
 
     if (/^https?:\/\//i.test(candidate.url) && !options.allowRemoteImages) {
+      exportCandidates.push(candidate);
       changed = true;
       continue;
     }

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -226,6 +226,10 @@ function rewriteImageAttributes(
   } else if (/^https?:\/\//i.test(rawSrc) && !options.allowRemoteImages) {
     setHtmlAttribute(attributes, 'data-remote-src', rawSrc);
     setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
+    const srcset = getHtmlAttribute(attributes, 'srcset')?.value;
+    if (srcset) {
+      setHtmlAttribute(attributes, 'data-export-srcset', srcset);
+    }
     setHtmlAttribute(attributes, 'src', '');
     setHtmlAttribute(attributes, 'srcset', '');
   }

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -99,14 +99,26 @@ function renderMathPlaceholder(
 function rewriteSrcsetAttribute(
   attributes: Array<{ name: string; value?: string }>,
   options: MarkdownRenderOptions
-): void {
+): {
+  previewCandidates: Array<{ url: string; descriptor?: string }>;
+  blockedRemoteCandidates: Array<{ url: string; descriptor?: string }>;
+  blockedBySizeLimit: boolean;
+  changed: boolean;
+} {
   const srcset = getHtmlAttribute(attributes, 'srcset')?.value;
   if (!srcset) {
-    return;
+    return {
+      previewCandidates: [],
+      blockedRemoteCandidates: [],
+      blockedBySizeLimit: false,
+      changed: false
+    };
   }
 
   const previewCandidates = [];
   const exportCandidates = [];
+  const blockedRemoteCandidates = [];
+  let blockedBySizeLimit = false;
   let changed = false;
 
   for (const candidate of parseHtmlSrcset(srcset)) {
@@ -135,6 +147,7 @@ function rewriteSrcsetAttribute(
       try {
         const bytes = statSync(resolved.fsPath).size;
         if (bytes > options.maxImageMB * 1024 * 1024) {
+          blockedBySizeLimit = true;
           changed = true;
           continue;
         }
@@ -152,6 +165,7 @@ function rewriteSrcsetAttribute(
 
     if (/^https?:\/\//i.test(candidate.url) && !options.allowRemoteImages) {
       exportCandidates.push(candidate);
+      blockedRemoteCandidates.push(candidate);
       changed = true;
       continue;
     }
@@ -161,7 +175,12 @@ function rewriteSrcsetAttribute(
   }
 
   if (!changed) {
-    return;
+    return {
+      previewCandidates,
+      blockedRemoteCandidates,
+      blockedBySizeLimit,
+      changed
+    };
   }
 
   setHtmlAttribute(
@@ -174,6 +193,12 @@ function rewriteSrcsetAttribute(
     'srcset',
     serializeHtmlSrcset(previewCandidates)
   );
+  return {
+    previewCandidates,
+    blockedRemoteCandidates,
+    blockedBySizeLimit,
+    changed
+  };
 }
 
 function rewriteImageAttributes(
@@ -227,12 +252,11 @@ function rewriteImageAttributes(
     setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
   }
 
-  rewriteSrcsetAttribute(attributes, options);
+  const srcsetRewrite = rewriteSrcsetAttribute(attributes, options);
 
   if (blockedRemoteImage) {
-    const previewSrcset = getHtmlAttribute(attributes, 'srcset')?.value;
-    if (previewSrcset) {
-      const previewSrc = parseHtmlSrcset(previewSrcset)[0]?.url;
+    if (srcsetRewrite.previewCandidates.length > 0) {
+      const previewSrc = srcsetRewrite.previewCandidates[0]?.url;
       setHtmlAttribute(attributes, 'src', previewSrc ?? '');
     } else {
       setHtmlAttribute(attributes, 'srcset', '');
@@ -260,7 +284,6 @@ function rewriteRawHtmlImages(
       getHtmlAttribute(parsed.attributes, 'data-local-src') ||
       getHtmlAttribute(parsed.attributes, 'data-remote-src') ||
       getHtmlAttribute(parsed.attributes, 'data-image-blocked') ||
-      getHtmlAttribute(parsed.attributes, 'data-max-mb') ||
       getHtmlAttribute(parsed.attributes, 'data-export-srcset')
     ) {
       return tag;
@@ -275,7 +298,34 @@ function rewriteRawHtmlImages(
     if (src) {
       rewriteImageAttributes(parsed.attributes, src, options);
     } else {
-      rewriteSrcsetAttribute(parsed.attributes, options);
+      const srcsetRewrite = rewriteSrcsetAttribute(parsed.attributes, options);
+      if (
+        srcsetRewrite.changed &&
+        srcsetRewrite.previewCandidates.length === 0
+      ) {
+        if (srcsetRewrite.blockedRemoteCandidates.length > 0) {
+          setHtmlAttribute(
+            parsed.attributes,
+            'data-remote-src',
+            srcsetRewrite.blockedRemoteCandidates[0].url
+          );
+          setHtmlAttribute(
+            parsed.attributes,
+            'data-image-blocked',
+            'remote-disabled'
+          );
+          setHtmlAttribute(parsed.attributes, 'src', '');
+        } else if (srcsetRewrite.blockedBySizeLimit) {
+          const alt = getHtmlAttribute(parsed.attributes, 'alt')?.value ?? 'image';
+          setHtmlAttribute(
+            parsed.attributes,
+            'alt',
+            `${alt} (blocked: exceeds preview.maxImageMB)`
+          );
+          setHtmlAttribute(parsed.attributes, 'data-image-blocked', 'size-limit');
+          setHtmlAttribute(parsed.attributes, 'src', '');
+        }
+      }
       setHtmlAttribute(parsed.attributes, 'loading', 'lazy');
       setHtmlAttribute(parsed.attributes, 'decoding', 'async');
       setHtmlAttribute(parsed.attributes, 'referrerpolicy', 'no-referrer');

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -267,11 +267,24 @@ function rewriteRawHtmlImages(
     }
 
     const src = getHtmlAttribute(parsed.attributes, 'src')?.value;
-    if (!src) {
+    const srcset = getHtmlAttribute(parsed.attributes, 'srcset')?.value;
+    if (!src && !srcset) {
       return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
     }
 
-    rewriteImageAttributes(parsed.attributes, src, options);
+    if (src) {
+      rewriteImageAttributes(parsed.attributes, src, options);
+    } else {
+      rewriteSrcsetAttribute(parsed.attributes, options);
+      setHtmlAttribute(parsed.attributes, 'loading', 'lazy');
+      setHtmlAttribute(parsed.attributes, 'decoding', 'async');
+      setHtmlAttribute(parsed.attributes, 'referrerpolicy', 'no-referrer');
+      setHtmlAttribute(
+        parsed.attributes,
+        'data-max-mb',
+        String(options.maxImageMB)
+      );
+    }
     return serializeHtmlImgTag(parsed.attributes, parsed.selfClosing);
   });
 }

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -201,6 +201,22 @@ function rewriteSrcsetAttribute(
   };
 }
 
+function setBlockedRemoteImageMetadata(
+  attributes: Array<{ name: string; value?: string }>,
+  blockedCandidates: Array<{ url: string }>
+): void {
+  if (blockedCandidates.length === 0) {
+    return;
+  }
+
+  if (!getHtmlAttribute(attributes, 'data-remote-src')?.value) {
+    setHtmlAttribute(attributes, 'data-remote-src', blockedCandidates[0].url);
+  }
+  if (!getHtmlAttribute(attributes, 'data-image-blocked')?.value) {
+    setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
+  }
+}
+
 function rewriteImageAttributes(
   attributes: Array<{ name: string; value?: string }>,
   rawSrc: string,
@@ -253,6 +269,10 @@ function rewriteImageAttributes(
   }
 
   const srcsetRewrite = rewriteSrcsetAttribute(attributes, options);
+  setBlockedRemoteImageMetadata(
+    attributes,
+    srcsetRewrite.blockedRemoteCandidates
+  );
 
   if (blockedRemoteImage) {
     if (srcsetRewrite.previewCandidates.length > 0) {
@@ -299,21 +319,15 @@ function rewriteRawHtmlImages(
       rewriteImageAttributes(parsed.attributes, src, options);
     } else {
       const srcsetRewrite = rewriteSrcsetAttribute(parsed.attributes, options);
+      setBlockedRemoteImageMetadata(
+        parsed.attributes,
+        srcsetRewrite.blockedRemoteCandidates
+      );
       if (
         srcsetRewrite.changed &&
         srcsetRewrite.previewCandidates.length === 0
       ) {
         if (srcsetRewrite.blockedRemoteCandidates.length > 0) {
-          setHtmlAttribute(
-            parsed.attributes,
-            'data-remote-src',
-            srcsetRewrite.blockedRemoteCandidates[0].url
-          );
-          setHtmlAttribute(
-            parsed.attributes,
-            'data-image-blocked',
-            'remote-disabled'
-          );
           setHtmlAttribute(parsed.attributes, 'src', '');
         } else if (srcsetRewrite.blockedBySizeLimit) {
           const alt = getHtmlAttribute(parsed.attributes, 'alt')?.value ?? 'image';

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -226,6 +226,7 @@ function rewriteImageAttributes(
   const resolved = resolveImageUri(options.sourceUri, rawSrc);
   const blockedRemoteImage =
     /^https?:\/\//i.test(rawSrc) && !options.allowRemoteImages;
+  let blockedBySizeLimit = false;
 
   if (override) {
     setHtmlAttribute(attributes, 'data-local-src', override.toString());
@@ -239,13 +240,7 @@ function rewriteImageAttributes(
     try {
       const bytes = statSync(resolved.fsPath).size;
       if (bytes > options.maxImageMB * 1024 * 1024) {
-        const alt = getHtmlAttribute(attributes, 'alt')?.value ?? 'image';
-        setHtmlAttribute(
-          attributes,
-          'alt',
-          `${alt} (blocked: exceeds preview.maxImageMB)`
-        );
-        setHtmlAttribute(attributes, 'data-image-blocked', 'size-limit');
+        blockedBySizeLimit = true;
         setHtmlAttribute(attributes, 'src', '');
         setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
       } else {
@@ -282,6 +277,16 @@ function rewriteImageAttributes(
       setHtmlAttribute(attributes, 'srcset', '');
       setHtmlAttribute(attributes, 'src', '');
     }
+  }
+
+  if (blockedBySizeLimit && srcsetRewrite.previewCandidates.length === 0) {
+    const alt = getHtmlAttribute(attributes, 'alt')?.value ?? 'image';
+    setHtmlAttribute(
+      attributes,
+      'alt',
+      `${alt} (blocked: exceeds preview.maxImageMB)`
+    );
+    setHtmlAttribute(attributes, 'data-image-blocked', 'size-limit');
   }
 
   setHtmlAttribute(attributes, 'loading', 'lazy');

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -11,7 +11,9 @@ import {
   getHtmlAttribute,
   mapHtmlImgTags,
   parseHtmlImgTag,
+  parseHtmlSrcset,
   serializeHtmlImgTag,
+  serializeHtmlSrcset,
   setHtmlAttribute
 } from '../htmlImageTags';
 import { parseFrontmatter } from './frontmatter';
@@ -94,6 +96,85 @@ function renderMathPlaceholder(
   return `<span class="${className}"${extraAttrs} data-math="${encodeMathExpression(expr)}"></span>`;
 }
 
+function rewriteSrcsetAttribute(
+  attributes: Array<{ name: string; value?: string }>,
+  options: MarkdownRenderOptions
+): void {
+  const srcset = getHtmlAttribute(attributes, 'srcset')?.value;
+  if (!srcset) {
+    return;
+  }
+
+  const previewCandidates = [];
+  const exportCandidates = [];
+  let changed = false;
+
+  for (const candidate of parseHtmlSrcset(srcset)) {
+    const override = options.remoteImageOverrides?.get(candidate.url);
+    const resolved = resolveImageUri(options.sourceUri, candidate.url);
+
+    if (override) {
+      previewCandidates.push({
+        url: options.webview.asWebviewUri(override).toString(),
+        descriptor: candidate.descriptor
+      });
+      exportCandidates.push({
+        url: override.toString(),
+        descriptor: candidate.descriptor
+      });
+      changed = true;
+      continue;
+    }
+
+    if (resolved) {
+      exportCandidates.push({
+        url: resolved.toString(),
+        descriptor: candidate.descriptor
+      });
+
+      try {
+        const bytes = statSync(resolved.fsPath).size;
+        if (bytes > options.maxImageMB * 1024 * 1024) {
+          changed = true;
+          continue;
+        }
+      } catch {
+        // If stat fails we still rewrite to a webview URI and let runtime loading decide the result.
+      }
+
+      previewCandidates.push({
+        url: options.webview.asWebviewUri(resolved).toString(),
+        descriptor: candidate.descriptor
+      });
+      changed = true;
+      continue;
+    }
+
+    if (/^https?:\/\//i.test(candidate.url) && !options.allowRemoteImages) {
+      changed = true;
+      continue;
+    }
+
+    previewCandidates.push(candidate);
+    exportCandidates.push(candidate);
+  }
+
+  if (!changed) {
+    return;
+  }
+
+  setHtmlAttribute(
+    attributes,
+    'data-export-srcset',
+    serializeHtmlSrcset(exportCandidates)
+  );
+  setHtmlAttribute(
+    attributes,
+    'srcset',
+    serializeHtmlSrcset(previewCandidates)
+  );
+}
+
 function rewriteImageAttributes(
   attributes: Array<{ name: string; value?: string }>,
   rawSrc: string,
@@ -110,6 +191,7 @@ function rewriteImageAttributes(
       options.webview.asWebviewUri(override).toString()
     );
   } else if (resolved) {
+    setHtmlAttribute(attributes, 'data-local-src', resolved.toString());
     try {
       const bytes = statSync(resolved.fsPath).size;
       if (bytes > options.maxImageMB * 1024 * 1024) {
@@ -122,18 +204,23 @@ function rewriteImageAttributes(
         setHtmlAttribute(attributes, 'data-image-blocked', 'size-limit');
         setHtmlAttribute(attributes, 'src', '');
         setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
-        return;
+      } else {
+        setHtmlAttribute(
+          attributes,
+          'src',
+          options.webview.asWebviewUri(resolved).toString()
+        );
+        rewriteSrcsetAttribute(attributes, options);
       }
     } catch {
       // If stat fails we still rewrite to a webview URI and let runtime loading decide the result.
+      setHtmlAttribute(
+        attributes,
+        'src',
+        options.webview.asWebviewUri(resolved).toString()
+      );
+      rewriteSrcsetAttribute(attributes, options);
     }
-
-    setHtmlAttribute(attributes, 'data-local-src', resolved.toString());
-    setHtmlAttribute(
-      attributes,
-      'src',
-      options.webview.asWebviewUri(resolved).toString()
-    );
   } else if (/^https?:\/\//i.test(rawSrc) && !options.allowRemoteImages) {
     setHtmlAttribute(attributes, 'data-remote-src', rawSrc);
     setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
@@ -160,7 +247,8 @@ function rewriteRawHtmlImages(
       getHtmlAttribute(parsed.attributes, 'data-local-src') ||
       getHtmlAttribute(parsed.attributes, 'data-remote-src') ||
       getHtmlAttribute(parsed.attributes, 'data-image-blocked') ||
-      getHtmlAttribute(parsed.attributes, 'data-max-mb')
+      getHtmlAttribute(parsed.attributes, 'data-max-mb') ||
+      getHtmlAttribute(parsed.attributes, 'data-export-srcset')
     ) {
       return tag;
     }

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -107,7 +107,7 @@ function parseHtmlImgTag(tag: string): {
   const body = tag.replace(/^<img\b/i, '').replace(/\s*\/?>$/, '');
   const attributes: HtmlAttribute[] = [];
   const attrPattern =
-    /([^\s"'=<>`\/]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+    /([^\s"'=<>`/]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
 
   for (const match of body.matchAll(attrPattern)) {
     const name = match[1];
@@ -221,6 +221,15 @@ function rewriteRawHtmlImages(
   return html.replace(/<img\b[^>]*>/gi, (tag) => {
     const parsed = parseHtmlImgTag(tag);
     if (!parsed) {
+      return tag;
+    }
+
+    if (
+      getHtmlAttribute(parsed.attributes, 'data-local-src') ||
+      getHtmlAttribute(parsed.attributes, 'data-remote-src') ||
+      getHtmlAttribute(parsed.attributes, 'data-image-blocked') ||
+      getHtmlAttribute(parsed.attributes, 'data-max-mb')
+    ) {
       return tag;
     }
 

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -266,7 +266,6 @@ function rewriteImageAttributes(
       if (bytes > options.maxImageMB * 1024 * 1024) {
         blockedBySizeLimit = true;
         setHtmlAttribute(attributes, 'src', '');
-        setHtmlAttribute(attributes, OMV_MAX_MB_ATTR, String(options.maxImageMB));
       } else {
         setHtmlAttribute(
           attributes,

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -8,6 +8,15 @@ import taskLists from 'markdown-it-task-lists';
 
 import type { FrontmatterInfo, TocItem } from '../../messaging/protocol';
 import {
+  OMV_EXPORT_SRCSET_ATTR,
+  OMV_IMAGE_BLOCKED_ATTR,
+  OMV_IMAGE_BLOCKED_REMOTE_DISABLED,
+  OMV_IMAGE_BLOCKED_SIZE_LIMIT,
+  OMV_LOCAL_SRC_ATTR,
+  OMV_MAX_MB_ATTR,
+  OMV_REMOTE_SRC_ATTR
+} from '../../../previewImageMetadata';
+import {
   getHtmlAttribute,
   mapHtmlImgTags,
   parseHtmlImgTag,
@@ -185,7 +194,7 @@ function rewriteSrcsetAttribute(
 
   setHtmlAttribute(
     attributes,
-    'data-export-srcset',
+    OMV_EXPORT_SRCSET_ATTR,
     serializeHtmlSrcset(exportCandidates)
   );
   setHtmlAttribute(
@@ -209,12 +218,27 @@ function setBlockedRemoteImageMetadata(
     return;
   }
 
-  if (!getHtmlAttribute(attributes, 'data-remote-src')?.value) {
-    setHtmlAttribute(attributes, 'data-remote-src', blockedCandidates[0].url);
+  if (!getHtmlAttribute(attributes, OMV_REMOTE_SRC_ATTR)?.value) {
+    setHtmlAttribute(attributes, OMV_REMOTE_SRC_ATTR, blockedCandidates[0].url);
   }
-  if (!getHtmlAttribute(attributes, 'data-image-blocked')?.value) {
-    setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
+  if (!getHtmlAttribute(attributes, OMV_IMAGE_BLOCKED_ATTR)?.value) {
+    setHtmlAttribute(
+      attributes,
+      OMV_IMAGE_BLOCKED_ATTR,
+      OMV_IMAGE_BLOCKED_REMOTE_DISABLED
+    );
   }
+}
+
+function setHtmlAttributeIfAbsent(
+  attributes: Array<{ name: string; value?: string }>,
+  name: string,
+  value: string
+): void {
+  if (getHtmlAttribute(attributes, name)) {
+    return;
+  }
+  setHtmlAttribute(attributes, name, value);
 }
 
 function rewriteImageAttributes(
@@ -229,20 +253,20 @@ function rewriteImageAttributes(
   let blockedBySizeLimit = false;
 
   if (override) {
-    setHtmlAttribute(attributes, 'data-local-src', override.toString());
+    setHtmlAttribute(attributes, OMV_LOCAL_SRC_ATTR, override.toString());
     setHtmlAttribute(
       attributes,
       'src',
       options.webview.asWebviewUri(override).toString()
     );
   } else if (resolved) {
-    setHtmlAttribute(attributes, 'data-local-src', resolved.toString());
+    setHtmlAttribute(attributes, OMV_LOCAL_SRC_ATTR, resolved.toString());
     try {
       const bytes = statSync(resolved.fsPath).size;
       if (bytes > options.maxImageMB * 1024 * 1024) {
         blockedBySizeLimit = true;
         setHtmlAttribute(attributes, 'src', '');
-        setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
+        setHtmlAttribute(attributes, OMV_MAX_MB_ATTR, String(options.maxImageMB));
       } else {
         setHtmlAttribute(
           attributes,
@@ -259,8 +283,12 @@ function rewriteImageAttributes(
       );
     }
   } else if (blockedRemoteImage) {
-    setHtmlAttribute(attributes, 'data-remote-src', rawSrc);
-    setHtmlAttribute(attributes, 'data-image-blocked', 'remote-disabled');
+    setHtmlAttribute(attributes, OMV_REMOTE_SRC_ATTR, rawSrc);
+    setHtmlAttribute(
+      attributes,
+      OMV_IMAGE_BLOCKED_ATTR,
+      OMV_IMAGE_BLOCKED_REMOTE_DISABLED
+    );
   }
 
   const srcsetRewrite = rewriteSrcsetAttribute(attributes, options);
@@ -286,13 +314,17 @@ function rewriteImageAttributes(
       'alt',
       `${alt} (blocked: exceeds preview.maxImageMB)`
     );
-    setHtmlAttribute(attributes, 'data-image-blocked', 'size-limit');
+    setHtmlAttribute(
+      attributes,
+      OMV_IMAGE_BLOCKED_ATTR,
+      OMV_IMAGE_BLOCKED_SIZE_LIMIT
+    );
   }
 
-  setHtmlAttribute(attributes, 'loading', 'lazy');
-  setHtmlAttribute(attributes, 'decoding', 'async');
-  setHtmlAttribute(attributes, 'referrerpolicy', 'no-referrer');
-  setHtmlAttribute(attributes, 'data-max-mb', String(options.maxImageMB));
+  setHtmlAttributeIfAbsent(attributes, 'loading', 'lazy');
+  setHtmlAttributeIfAbsent(attributes, 'decoding', 'async');
+  setHtmlAttributeIfAbsent(attributes, 'referrerpolicy', 'no-referrer');
+  setHtmlAttribute(attributes, OMV_MAX_MB_ATTR, String(options.maxImageMB));
 }
 
 function rewriteRawHtmlImages(
@@ -306,10 +338,10 @@ function rewriteRawHtmlImages(
     }
 
     if (
-      getHtmlAttribute(parsed.attributes, 'data-local-src') ||
-      getHtmlAttribute(parsed.attributes, 'data-remote-src') ||
-      getHtmlAttribute(parsed.attributes, 'data-image-blocked') ||
-      getHtmlAttribute(parsed.attributes, 'data-export-srcset')
+      getHtmlAttribute(parsed.attributes, OMV_LOCAL_SRC_ATTR) ||
+      getHtmlAttribute(parsed.attributes, OMV_REMOTE_SRC_ATTR) ||
+      getHtmlAttribute(parsed.attributes, OMV_IMAGE_BLOCKED_ATTR) ||
+      getHtmlAttribute(parsed.attributes, OMV_EXPORT_SRCSET_ATTR)
     ) {
       return tag;
     }
@@ -341,16 +373,24 @@ function rewriteRawHtmlImages(
             'alt',
             `${alt} (blocked: exceeds preview.maxImageMB)`
           );
-          setHtmlAttribute(parsed.attributes, 'data-image-blocked', 'size-limit');
+          setHtmlAttribute(
+            parsed.attributes,
+            OMV_IMAGE_BLOCKED_ATTR,
+            OMV_IMAGE_BLOCKED_SIZE_LIMIT
+          );
           setHtmlAttribute(parsed.attributes, 'src', '');
         }
       }
-      setHtmlAttribute(parsed.attributes, 'loading', 'lazy');
-      setHtmlAttribute(parsed.attributes, 'decoding', 'async');
-      setHtmlAttribute(parsed.attributes, 'referrerpolicy', 'no-referrer');
+      setHtmlAttributeIfAbsent(parsed.attributes, 'loading', 'lazy');
+      setHtmlAttributeIfAbsent(parsed.attributes, 'decoding', 'async');
+      setHtmlAttributeIfAbsent(
+        parsed.attributes,
+        'referrerpolicy',
+        'no-referrer'
+      );
       setHtmlAttribute(
         parsed.attributes,
-        'data-max-mb',
+        OMV_MAX_MB_ATTR,
         String(options.maxImageMB)
       );
     }
@@ -581,7 +621,7 @@ function createMarkdownIt(options: MarkdownRenderOptions): MarkdownIt {
     const override = options.remoteImageOverrides?.get(src);
     const resolved = resolveImageUri(options.sourceUri, src);
     if (override) {
-      token.attrSet('data-local-src', override.toString());
+      token.attrSet(OMV_LOCAL_SRC_ATTR, override.toString());
       token.attrSet('src', options.webview.asWebviewUri(override).toString());
     } else if (resolved) {
       try {
@@ -591,24 +631,27 @@ function createMarkdownIt(options: MarkdownRenderOptions): MarkdownIt {
             'alt',
             `${token.attrGet('alt') ?? 'image'} (blocked: exceeds preview.maxImageMB)`
           );
-          token.attrSet('data-image-blocked', 'size-limit');
+          token.attrSet(OMV_IMAGE_BLOCKED_ATTR, OMV_IMAGE_BLOCKED_SIZE_LIMIT);
           token.attrSet('src', '');
           return imageRule ? imageRule(tokens, idx, opts, env, self) : self.renderToken(tokens, idx, opts);
         }
       } catch {
         // If stat fails we leave the original src untouched; CSP/runtime policy governs remote sources.
       }
-      token.attrSet('data-local-src', resolved.toString());
+      token.attrSet(OMV_LOCAL_SRC_ATTR, resolved.toString());
       token.attrSet('src', options.webview.asWebviewUri(resolved).toString());
     } else if (/^https?:\/\//i.test(src) && !options.allowRemoteImages) {
-      token.attrSet('data-remote-src', src);
-      token.attrSet('data-image-blocked', 'remote-disabled');
+      token.attrSet(OMV_REMOTE_SRC_ATTR, src);
+      token.attrSet(
+        OMV_IMAGE_BLOCKED_ATTR,
+        OMV_IMAGE_BLOCKED_REMOTE_DISABLED
+      );
       token.attrSet('src', '');
     }
     token.attrSet('loading', 'lazy');
     token.attrSet('decoding', 'async');
     token.attrSet('referrerpolicy', 'no-referrer');
-    token.attrSet('data-max-mb', String(options.maxImageMB));
+    token.attrSet(OMV_MAX_MB_ATTR, String(options.maxImageMB));
     return imageRule ? imageRule(tokens, idx, opts, env, self) : self.renderToken(tokens, idx, opts);
   };
 

--- a/src/extension/preview/markdown/markdownPipeline.ts
+++ b/src/extension/preview/markdown/markdownPipeline.ts
@@ -7,6 +7,13 @@ import footnote from 'markdown-it-footnote';
 import taskLists from 'markdown-it-task-lists';
 
 import type { FrontmatterInfo, TocItem } from '../../messaging/protocol';
+import {
+  getHtmlAttribute,
+  mapHtmlImgTags,
+  parseHtmlImgTag,
+  serializeHtmlImgTag,
+  setHtmlAttribute
+} from '../htmlImageTags';
 import { parseFrontmatter } from './frontmatter';
 import { resolveImageUri } from './linkResolver';
 
@@ -28,11 +35,6 @@ export interface MarkdownRenderResult {
   toc: TocItem[];
   frontmatter?: FrontmatterInfo;
   lineCount: number;
-}
-
-interface HtmlAttribute {
-  name: string;
-  value?: string;
 }
 
 function slugify(value: string): string {
@@ -92,78 +94,8 @@ function renderMathPlaceholder(
   return `<span class="${className}"${extraAttrs} data-math="${encodeMathExpression(expr)}"></span>`;
 }
 
-function escapeHtmlAttribute(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-function parseHtmlImgTag(tag: string): {
-  attributes: HtmlAttribute[];
-  selfClosing: boolean;
-} | null {
-  const body = tag.replace(/^<img\b/i, '').replace(/\s*\/?>$/, '');
-  const attributes: HtmlAttribute[] = [];
-  const attrPattern =
-    /([^\s"'=<>`/]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
-
-  for (const match of body.matchAll(attrPattern)) {
-    const name = match[1];
-    const value = match[2] ?? match[3] ?? match[4];
-    attributes.push(
-      value === undefined ? { name } : { name, value }
-    );
-  }
-
-  return {
-    attributes,
-    selfClosing: /\/\s*>$/.test(tag)
-  };
-}
-
-function serializeHtmlImgTag(
-  attributes: HtmlAttribute[],
-  selfClosing: boolean
-): string {
-  const renderedAttrs = attributes
-    .map((attr) =>
-      attr.value === undefined
-        ? ` ${attr.name}`
-        : ` ${attr.name}="${escapeHtmlAttribute(attr.value)}"`
-    )
-    .join('');
-  return `<img${renderedAttrs}${selfClosing ? ' />' : '>'}`;
-}
-
-function setHtmlAttribute(
-  attributes: HtmlAttribute[],
-  name: string,
-  value: string
-): void {
-  const existing = attributes.find(
-    (attr) => attr.name.toLowerCase() === name.toLowerCase()
-  );
-  if (existing) {
-    existing.name = name;
-    existing.value = value;
-    return;
-  }
-  attributes.push({ name, value });
-}
-
-function getHtmlAttribute(
-  attributes: HtmlAttribute[],
-  name: string
-): HtmlAttribute | undefined {
-  return attributes.find(
-    (attr) => attr.name.toLowerCase() === name.toLowerCase()
-  );
-}
-
 function rewriteImageAttributes(
-  attributes: HtmlAttribute[],
+  attributes: Array<{ name: string; value?: string }>,
   rawSrc: string,
   options: MarkdownRenderOptions
 ): void {
@@ -218,7 +150,7 @@ function rewriteRawHtmlImages(
   html: string,
   options: MarkdownRenderOptions
 ): string {
-  return html.replace(/<img\b[^>]*>/gi, (tag) => {
+  return mapHtmlImgTags(html, (tag) => {
     const parsed = parseHtmlImgTag(tag);
     if (!parsed) {
       return tag;

--- a/src/previewImageMetadata.ts
+++ b/src/previewImageMetadata.ts
@@ -1,0 +1,8 @@
+export const OMV_LOCAL_SRC_ATTR = 'data-omv-local-src';
+export const OMV_REMOTE_SRC_ATTR = 'data-omv-remote-src';
+export const OMV_EXPORT_SRCSET_ATTR = 'data-omv-export-srcset';
+export const OMV_IMAGE_BLOCKED_ATTR = 'data-omv-image-blocked';
+export const OMV_MAX_MB_ATTR = 'data-omv-max-mb';
+
+export const OMV_IMAGE_BLOCKED_REMOTE_DISABLED = 'remote-disabled';
+export const OMV_IMAGE_BLOCKED_SIZE_LIMIT = 'size-limit';

--- a/src/webview-ui/app/remoteImageAttrs.ts
+++ b/src/webview-ui/app/remoteImageAttrs.ts
@@ -1,0 +1,52 @@
+const PREVIEW_HIDDEN_MARKER = 'data-omv-preview-hidden';
+const PREVIEW_ARIA_HIDDEN_RESTORE_MARKER =
+  'data-omv-preview-restore-aria-hidden';
+const MISSING_ARIA_HIDDEN = '__omv_missing__';
+
+interface ImageAttributeTarget {
+  hidden: boolean;
+  hasAttribute(name: string): boolean;
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+}
+
+export function markRemoteImagePreviewHidden(
+  image: ImageAttributeTarget
+): void {
+  if (!image.hasAttribute('hidden')) {
+    image.setAttribute(PREVIEW_HIDDEN_MARKER, '1');
+  }
+
+  const originalAriaHidden = image.getAttribute('aria-hidden');
+  if (originalAriaHidden !== 'true') {
+    image.setAttribute(
+      PREVIEW_ARIA_HIDDEN_RESTORE_MARKER,
+      originalAriaHidden ?? MISSING_ARIA_HIDDEN
+    );
+  }
+
+  image.hidden = true;
+  image.setAttribute('aria-hidden', 'true');
+}
+
+export function restoreRemoteImageExportVisibility(
+  image: ImageAttributeTarget
+): void {
+  if (image.getAttribute(PREVIEW_HIDDEN_MARKER) === '1') {
+    image.hidden = false;
+    image.removeAttribute('hidden');
+  }
+
+  const restoreAriaHidden = image.getAttribute(
+    PREVIEW_ARIA_HIDDEN_RESTORE_MARKER
+  );
+  if (restoreAriaHidden === MISSING_ARIA_HIDDEN) {
+    image.removeAttribute('aria-hidden');
+  } else if (restoreAriaHidden !== null) {
+    image.setAttribute('aria-hidden', restoreAriaHidden);
+  }
+
+  image.removeAttribute(PREVIEW_HIDDEN_MARKER);
+  image.removeAttribute(PREVIEW_ARIA_HIDDEN_RESTORE_MARKER);
+}

--- a/src/webview-ui/app/renderer.ts
+++ b/src/webview-ui/app/renderer.ts
@@ -213,6 +213,11 @@ export class PreviewRenderer {
     for (const img of remoteImgs) {
       const src = img.getAttribute('data-remote-src');
       if (!src) continue;
+      const hasPreviewSource = Boolean(
+        (img.getAttribute('src') ?? '').trim() ||
+          (img.getAttribute('srcset') ?? '').trim()
+      );
+      if (hasPreviewSource) continue;
       const block = document.createElement('div');
       block.className = 'omv-remote-image';
 

--- a/src/webview-ui/app/renderer.ts
+++ b/src/webview-ui/app/renderer.ts
@@ -227,7 +227,9 @@ export class PreviewRenderer {
       btn.textContent = 'Download Image';
 
       block.append(text, btn);
-      img.replaceWith(block);
+      img.hidden = true;
+      img.setAttribute('aria-hidden', 'true');
+      img.insertAdjacentElement('afterend', block);
     }
   }
 

--- a/src/webview-ui/app/renderer.ts
+++ b/src/webview-ui/app/renderer.ts
@@ -13,6 +13,7 @@ import type {
   RenderPayload,
   TocItem
 } from '../../extension/messaging/protocol';
+import { markRemoteImagePreviewHidden } from './remoteImageAttrs';
 import { getEffectiveMermaidThemeKind } from './themeUtils';
 
 export interface RendererBridge {
@@ -234,8 +235,7 @@ export class PreviewRenderer {
 
       block.append(text, btn);
       if (!hasPreviewSource) {
-        img.hidden = true;
-        img.setAttribute('aria-hidden', 'true');
+        markRemoteImagePreviewHidden(img);
       }
       img.insertAdjacentElement('afterend', block);
     }

--- a/src/webview-ui/app/renderer.ts
+++ b/src/webview-ui/app/renderer.ts
@@ -217,13 +217,14 @@ export class PreviewRenderer {
         (img.getAttribute('src') ?? '').trim() ||
           (img.getAttribute('srcset') ?? '').trim()
       );
-      if (hasPreviewSource) continue;
       const block = document.createElement('div');
       block.className = 'omv-remote-image';
 
       const text = document.createElement('div');
       text.className = 'omv-remote-image-text';
-      text.textContent = 'Remote image blocked by settings.';
+      text.textContent = hasPreviewSource
+        ? 'Some remote image sources are blocked by settings.'
+        : 'Remote image blocked by settings.';
 
       const btn = document.createElement('button');
       btn.type = 'button';
@@ -232,8 +233,10 @@ export class PreviewRenderer {
       btn.textContent = 'Download Image';
 
       block.append(text, btn);
-      img.hidden = true;
-      img.setAttribute('aria-hidden', 'true');
+      if (!hasPreviewSource) {
+        img.hidden = true;
+        img.setAttribute('aria-hidden', 'true');
+      }
       img.insertAdjacentElement('afterend', block);
     }
   }

--- a/src/webview-ui/app/renderer.ts
+++ b/src/webview-ui/app/renderer.ts
@@ -13,6 +13,13 @@ import type {
   RenderPayload,
   TocItem
 } from '../../extension/messaging/protocol';
+import {
+  OMV_EXPORT_SRCSET_ATTR,
+  OMV_IMAGE_BLOCKED_ATTR,
+  OMV_LOCAL_SRC_ATTR,
+  OMV_MAX_MB_ATTR,
+  OMV_REMOTE_SRC_ATTR
+} from '../../previewImageMetadata';
 import { markRemoteImagePreviewHidden } from './remoteImageAttrs';
 import { getEffectiveMermaidThemeKind } from './themeUtils';
 
@@ -101,11 +108,11 @@ export class PreviewRenderer {
             'data-mermaid',
             'data-math',
             'data-omv-link',
-            'data-local-src',
-            'data-export-srcset',
-            'data-remote-src',
-            'data-image-blocked',
-            'data-max-mb',
+            OMV_LOCAL_SRC_ATTR,
+            OMV_EXPORT_SRCSET_ATTR,
+            OMV_REMOTE_SRC_ATTR,
+            OMV_IMAGE_BLOCKED_ATTR,
+            OMV_MAX_MB_ATTR,
             'data-source-line',
             'data-source-line-end',
             'data-align',
@@ -199,20 +206,20 @@ export class PreviewRenderer {
 
   private decorateImageActions(): void {
     const imgs = this.content.querySelectorAll<HTMLImageElement>(
-      'img[data-local-src]'
+      `img[${OMV_LOCAL_SRC_ATTR}]`
     );
     for (const img of imgs) {
       img.addEventListener('click', () => {
-        const localSrc = img.getAttribute('data-local-src');
+        const localSrc = img.getAttribute(OMV_LOCAL_SRC_ATTR);
         if (localSrc) this.bridge.onOpenImage(localSrc);
       });
     }
 
     const remoteImgs = this.content.querySelectorAll<HTMLImageElement>(
-      'img[data-remote-src]'
+      `img[${OMV_REMOTE_SRC_ATTR}]`
     );
     for (const img of remoteImgs) {
-      const src = img.getAttribute('data-remote-src');
+      const src = img.getAttribute(OMV_REMOTE_SRC_ATTR);
       if (!src) continue;
       const hasPreviewSource = Boolean(
         (img.getAttribute('src') ?? '').trim() ||

--- a/src/webview-ui/app/renderer.ts
+++ b/src/webview-ui/app/renderer.ts
@@ -101,6 +101,7 @@ export class PreviewRenderer {
             'data-math',
             'data-omv-link',
             'data-local-src',
+            'data-export-srcset',
             'data-remote-src',
             'data-image-blocked',
             'data-max-mb',

--- a/src/webview-ui/index.ts
+++ b/src/webview-ui/index.ts
@@ -7,6 +7,7 @@ import type {
   RenderPayload
 } from '../extension/messaging/protocol';
 import { parseExtensionMessage } from '../extension/messaging/validate';
+import { OMV_REMOTE_SRC_ATTR } from '../previewImageMetadata';
 import { PreviewRenderer } from './app/renderer';
 import { restoreRemoteImageExportVisibility } from './app/remoteImageAttrs';
 import { PreviewSearch } from './app/search';
@@ -453,7 +454,7 @@ function buildRenderedHtmlExportSnapshot(): {
   }
 
   for (const img of clone.querySelectorAll<HTMLImageElement>(
-    'img[data-remote-src]'
+    `img[${OMV_REMOTE_SRC_ATTR}]`
   )) {
     restoreRemoteImageExportVisibility(img);
   }

--- a/src/webview-ui/index.ts
+++ b/src/webview-ui/index.ts
@@ -8,6 +8,7 @@ import type {
 } from '../extension/messaging/protocol';
 import { parseExtensionMessage } from '../extension/messaging/validate';
 import { PreviewRenderer } from './app/renderer';
+import { restoreRemoteImageExportVisibility } from './app/remoteImageAttrs';
 import { PreviewSearch } from './app/search';
 import { ScrollSyncController } from './app/scrollSync';
 import { TocView } from './app/toc';
@@ -454,9 +455,7 @@ function buildRenderedHtmlExportSnapshot(): {
   for (const img of clone.querySelectorAll<HTMLImageElement>(
     'img[data-remote-src]'
   )) {
-    img.hidden = false;
-    img.removeAttribute('hidden');
-    img.removeAttribute('aria-hidden');
+    restoreRemoteImageExportVisibility(img);
   }
 
   // Remove preview-only state attrs.

--- a/src/webview-ui/index.ts
+++ b/src/webview-ui/index.ts
@@ -447,6 +447,18 @@ function buildRenderedHtmlExportSnapshot(): {
     }
   }
 
+  for (const block of clone.querySelectorAll<HTMLElement>('.omv-remote-image')) {
+    block.remove();
+  }
+
+  for (const img of clone.querySelectorAll<HTMLImageElement>(
+    'img[data-remote-src]'
+  )) {
+    img.hidden = false;
+    img.removeAttribute('hidden');
+    img.removeAttribute('aria-hidden');
+  }
+
   // Remove preview-only state attrs.
   for (const el of clone.querySelectorAll<HTMLElement>(
     '[aria-current],[aria-busy]'

--- a/test/unit/helpers/vscodeMock.ts
+++ b/test/unit/helpers/vscodeMock.ts
@@ -5,7 +5,9 @@ export class Uri {
     public readonly scheme: string,
     public readonly fsPath: string,
     public readonly path: string,
-    private readonly raw: string
+    private readonly raw: string,
+    public readonly query = '',
+    public readonly fragment = ''
   ) {}
 
   static file(fsPath: string): Uri {
@@ -15,8 +17,12 @@ export class Uri {
 
   static parse(input: string): Uri {
     if (input.startsWith('file://')) {
-      const p = input.slice('file://'.length);
-      return Uri.file(p);
+      const match = /^file:\/\/([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/i.exec(input);
+      const normalizedPath = (match?.[1] ?? '').replace(/\\/g, '/');
+      const fsPath = normalizedPath;
+      const query = match?.[2] ?? '';
+      const fragment = match?.[3] ?? '';
+      return new Uri('file', fsPath, normalizedPath, input, query, fragment);
     }
     if (/^https?:\/\//i.test(input)) {
       return new Uri(input.split(':')[0], '', '', input);
@@ -29,9 +35,25 @@ export class Uri {
     return Uri.file(nextPath);
   }
 
-  with(update: { path?: string }): Uri {
+  with(update: { path?: string; query?: string; fragment?: string }): Uri {
     const nextPath = update.path ?? this.path;
-    return Uri.file(nextPath);
+    const base =
+      this.scheme === 'file'
+        ? `file://${nextPath}`
+        : `${this.scheme}:${nextPath}`;
+    const nextQuery = update.query ?? this.query;
+    const nextFragment = update.fragment ?? this.fragment;
+    const nextRaw =
+      `${base}${nextQuery ? `?${nextQuery}` : ''}` +
+      `${nextFragment ? `#${nextFragment}` : ''}`;
+    return new Uri(
+      this.scheme,
+      nextPath,
+      nextPath,
+      nextRaw,
+      nextQuery,
+      nextFragment
+    );
   }
 
   toString(): string {

--- a/test/unit/helpers/vscodeMock.ts
+++ b/test/unit/helpers/vscodeMock.ts
@@ -1,5 +1,7 @@
 import * as path from 'node:path';
 
+const posixPath = path.posix;
+
 export class Uri {
   constructor(
     public readonly scheme: string,
@@ -31,7 +33,10 @@ export class Uri {
   }
 
   static joinPath(base: Uri, ...segments: string[]): Uri {
-    const nextPath = path.resolve(base.fsPath || base.path || '/', ...segments);
+    const nextPath = posixPath.resolve(
+      base.fsPath || base.path || '/',
+      ...segments
+    );
     return Uri.file(nextPath);
   }
 
@@ -64,7 +69,7 @@ export class Uri {
 export function createVscodeMock(workspaceRoot?: string) {
   const workspaceFolderPaths = workspaceRoot ? [workspaceRoot] : [];
   const workspaceFolders = workspaceFolderPaths.map((rootPath) => ({
-    name: path.basename(rootPath),
+    name: posixPath.basename(rootPath),
     uri: Uri.file(rootPath)
   }));
 
@@ -81,8 +86,11 @@ export function createVscodeMock(workspaceRoot?: string) {
       textDocuments: [],
       getWorkspaceFolder(uri: Uri) {
         return workspaceFolders.find((folder) => {
-          const rel = path.relative(folder.uri.fsPath, uri.fsPath);
-          return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+          const rel = posixPath.relative(folder.uri.fsPath, uri.fsPath);
+          return (
+            rel === '' ||
+            (!rel.startsWith('..') && !posixPath.isAbsolute(rel))
+          );
         });
       }
     }

--- a/test/unit/helpers/vscodeMock.ts
+++ b/test/unit/helpers/vscodeMock.ts
@@ -2,6 +2,26 @@ import * as path from 'node:path';
 
 const posixPath = path.posix;
 
+function normalizeSlashes(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function isWindowsDrivePath(value: string): boolean {
+  return /^[A-Za-z]:\//.test(normalizeSlashes(value));
+}
+
+function toUriPath(fsPath: string): string {
+  const normalized = normalizeSlashes(fsPath);
+  if (isWindowsDrivePath(normalized)) {
+    return `/${normalized}`;
+  }
+  return normalized;
+}
+
+function toFsPath(uriPath: string): string {
+  return /^\/[A-Za-z]:\//.test(uriPath) ? uriPath.slice(1) : uriPath;
+}
+
 export class Uri {
   constructor(
     public readonly scheme: string,
@@ -13,18 +33,19 @@ export class Uri {
   ) {}
 
   static file(fsPath: string): Uri {
-    const normalized = fsPath.replace(/\\/g, '/');
-    return new Uri('file', fsPath, normalized, `file://${normalized}`);
+    const normalizedFsPath = normalizeSlashes(fsPath);
+    const uriPath = toUriPath(normalizedFsPath);
+    return new Uri('file', normalizedFsPath, uriPath, `file://${uriPath}`);
   }
 
   static parse(input: string): Uri {
     if (input.startsWith('file://')) {
       const match = /^file:\/\/([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/i.exec(input);
-      const normalizedPath = (match?.[1] ?? '').replace(/\\/g, '/');
-      const fsPath = normalizedPath;
+      const uriPath = normalizeSlashes(match?.[1] ?? '');
+      const fsPath = toFsPath(uriPath);
       const query = match?.[2] ?? '';
       const fragment = match?.[3] ?? '';
-      return new Uri('file', fsPath, normalizedPath, input, query, fragment);
+      return new Uri('file', fsPath, uriPath, input, query, fragment);
     }
     if (/^https?:\/\//i.test(input)) {
       return new Uri(input.split(':')[0], '', '', input);
@@ -33,11 +54,13 @@ export class Uri {
   }
 
   static joinPath(base: Uri, ...segments: string[]): Uri {
-    const nextPath = posixPath.resolve(
-      base.fsPath || base.path || '/',
-      ...segments
+    const nextUriPath = posixPath.resolve(base.path || '/', ...segments);
+    return new Uri(
+      'file',
+      toFsPath(nextUriPath),
+      nextUriPath,
+      `file://${nextUriPath}`
     );
-    return Uri.file(nextPath);
   }
 
   with(update: { path?: string; query?: string; fragment?: string }): Uri {
@@ -53,7 +76,7 @@ export class Uri {
       `${nextFragment ? `#${nextFragment}` : ''}`;
     return new Uri(
       this.scheme,
-      nextPath,
+      this.scheme === 'file' ? toFsPath(nextPath) : nextPath,
       nextPath,
       nextRaw,
       nextQuery,
@@ -69,7 +92,7 @@ export class Uri {
 export function createVscodeMock(workspaceRoot?: string) {
   const workspaceFolderPaths = workspaceRoot ? [workspaceRoot] : [];
   const workspaceFolders = workspaceFolderPaths.map((rootPath) => ({
-    name: posixPath.basename(rootPath),
+    name: path.basename(normalizeSlashes(rootPath)),
     uri: Uri.file(rootPath)
   }));
 
@@ -86,11 +109,8 @@ export function createVscodeMock(workspaceRoot?: string) {
       textDocuments: [],
       getWorkspaceFolder(uri: Uri) {
         return workspaceFolders.find((folder) => {
-          const rel = posixPath.relative(folder.uri.fsPath, uri.fsPath);
-          return (
-            rel === '' ||
-            (!rel.startsWith('..') && !posixPath.isAbsolute(rel))
-          );
+          const rel = path.relative(folder.uri.fsPath, uri.fsPath);
+          return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
         });
       }
     }

--- a/test/unit/htmlImageTags.test.ts
+++ b/test/unit/htmlImageTags.test.ts
@@ -86,4 +86,36 @@ describe('htmlImageTags', () => {
       }
     ]);
   });
+
+  it('preserves commas inside absolute http srcset URLs', () => {
+    const srcset =
+      'https://cdn.example.com/demo,retina.gif 2x, https://cdn.example.com/demo@3x.gif 3x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url: 'https://cdn.example.com/demo,retina.gif',
+        descriptor: '2x'
+      },
+      {
+        url: 'https://cdn.example.com/demo@3x.gif',
+        descriptor: '3x'
+      }
+    ]);
+  });
+
+  it('preserves commas inside file srcset URLs', () => {
+    const srcset =
+      'file:///tmp/demo,retina.gif 2x, file:///tmp/demo@3x.gif 3x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url: 'file:///tmp/demo,retina.gif',
+        descriptor: '2x'
+      },
+      {
+        url: 'file:///tmp/demo@3x.gif',
+        descriptor: '3x'
+      }
+    ]);
+  });
 });

--- a/test/unit/htmlImageTags.test.ts
+++ b/test/unit/htmlImageTags.test.ts
@@ -6,6 +6,20 @@ import {
 } from '../../src/extension/preview/htmlImageTags';
 
 describe('htmlImageTags', () => {
+  it('skips img tags inside HTML comments', () => {
+    const html =
+      '<!-- note > <img src="images/commented.png" alt="commented" /> --><p><img src="images/rendered.png" alt="rendered" /></p>';
+
+    const result = mapHtmlImgTags(html, (tag) => `[${tag}]`);
+
+    expect(result).toContain(
+      '<!-- note > <img src="images/commented.png" alt="commented" /> -->'
+    );
+    expect(result).toContain(
+      '<p>[<img src="images/rendered.png" alt="rendered" />]</p>'
+    );
+  });
+
   it('skips img tags nested inside inert HTML containers', () => {
     const html = [
       '<template><img src="images/template.png" alt="template" /></template>',

--- a/test/unit/htmlImageTags.test.ts
+++ b/test/unit/htmlImageTags.test.ts
@@ -58,4 +58,18 @@ describe('htmlImageTags', () => {
       }
     ]);
   });
+
+  it('splits comma-separated candidates even when no whitespace follows the comma', () => {
+    const srcset = 'small.jpg,large.jpg 2x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url: 'small.jpg'
+      },
+      {
+        url: 'large.jpg',
+        descriptor: '2x'
+      }
+    ]);
+  });
 });

--- a/test/unit/htmlImageTags.test.ts
+++ b/test/unit/htmlImageTags.test.ts
@@ -87,6 +87,45 @@ describe('htmlImageTags', () => {
     ]);
   });
 
+  it('splits compact root-relative candidates without file extensions', () => {
+    const srcset = '/image?id=1,/image?id=2 2x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url: '/image?id=1'
+      },
+      {
+        url: '/image?id=2',
+        descriptor: '2x'
+      }
+    ]);
+  });
+
+  it('splits compact protocol-relative candidates without file extensions', () => {
+    const srcset = '//cdn.example.com/a,//cdn.example.com/b 2x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url: '//cdn.example.com/a'
+      },
+      {
+        url: '//cdn.example.com/b',
+        descriptor: '2x'
+      }
+    ]);
+  });
+
+  it('preserves commas in root-relative URLs when the right side is not another root-relative candidate', () => {
+    const srcset = '/api/image,retina 2x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url: '/api/image,retina',
+        descriptor: '2x'
+      }
+    ]);
+  });
+
   it('preserves commas inside absolute http srcset URLs', () => {
     const srcset =
       'https://cdn.example.com/demo,retina.gif 2x, https://cdn.example.com/demo@3x.gif 3x';

--- a/test/unit/htmlImageTags.test.ts
+++ b/test/unit/htmlImageTags.test.ts
@@ -42,4 +42,20 @@ describe('htmlImageTags', () => {
       }
     ]);
   });
+
+  it('preserves commas that are part of non-data srcset URLs', () => {
+    const srcset =
+      'images/scroll,final.gif 1x, https://example.com/scroll.gif?sig=a,b 2x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url: 'images/scroll,final.gif',
+        descriptor: '1x'
+      },
+      {
+        url: 'https://example.com/scroll.gif?sig=a,b',
+        descriptor: '2x'
+      }
+    ]);
+  });
 });

--- a/test/unit/htmlImageTags.test.ts
+++ b/test/unit/htmlImageTags.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapHtmlImgTags,
+  parseHtmlSrcset
+} from '../../src/extension/preview/htmlImageTags';
+
+describe('htmlImageTags', () => {
+  it('skips img tags nested inside inert HTML containers', () => {
+    const html = [
+      '<template><img src="images/template.png" alt="template" /></template>',
+      '<noscript><img src="images/noscript.png" alt="noscript" /></noscript>',
+      '<p><img src="images/rendered.png" alt="rendered" /></p>'
+    ].join('');
+
+    const result = mapHtmlImgTags(html, (tag) => `[${tag}]`);
+
+    expect(result).toContain(
+      '<template><img src="images/template.png" alt="template" /></template>'
+    );
+    expect(result).toContain(
+      '<noscript><img src="images/noscript.png" alt="noscript" /></noscript>'
+    );
+    expect(result).toContain(
+      '<p>[<img src="images/rendered.png" alt="rendered" />]</p>'
+    );
+  });
+
+  it('preserves inline SVG data URIs inside srcset candidates', () => {
+    const srcset =
+      'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg> 1x, images/scroll@2x.gif 2x';
+
+    expect(parseHtmlSrcset(srcset)).toEqual([
+      {
+        url:
+          'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>',
+        descriptor: '1x'
+      },
+      {
+        url: 'images/scroll@2x.gif',
+        descriptor: '2x'
+      }
+    ]);
+  });
+});

--- a/test/unit/htmlImageTags.test.ts
+++ b/test/unit/htmlImageTags.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   mapHtmlImgTags,
+  parseHtmlImgTag,
   parseHtmlSrcset
 } from '../../src/extension/preview/htmlImageTags';
 
@@ -34,6 +35,42 @@ describe('htmlImageTags', () => {
     );
     expect(result).toContain(
       '<noscript><img src="images/noscript.png" alt="noscript" /></noscript>'
+    );
+    expect(result).toContain(
+      '<p>[<img src="images/rendered.png" alt="rendered" />]</p>'
+    );
+  });
+
+  it('keeps a trailing slash in unquoted attribute values', () => {
+    const parsed = parseHtmlImgTag('<img src=demo.gif/>');
+
+    expect(parsed).toEqual({
+      attributes: [
+        {
+          name: 'src',
+          value: 'demo.gif/',
+          originalValue: 'demo.gif/',
+          quote: undefined,
+          changed: false
+        }
+      ],
+      selfClosing: false
+    });
+  });
+
+  it('skips img tags inside nested templates and template comments', () => {
+    const html = [
+      '<template>',
+      '  <!-- stray </template> marker inside comment -->',
+      '  <template><img src="images/nested.png" alt="nested" /></template>',
+      '</template>',
+      '<p><img src="images/rendered.png" alt="rendered" /></p>'
+    ].join('');
+
+    const result = mapHtmlImgTags(html, (tag) => `[${tag}]`);
+
+    expect(result).toContain(
+      '<template>  <!-- stray </template> marker inside comment -->  <template><img src="images/nested.png" alt="nested" /></template></template>'
     );
     expect(result).toContain(
       '<p>[<img src="images/rendered.png" alt="rendered" />]</p>'

--- a/test/unit/linkResolver.test.ts
+++ b/test/unit/linkResolver.test.ts
@@ -28,4 +28,18 @@ describe('linkResolver', () => {
     const source = Uri.file('/workspace/docs/a.md');
     expect(api.resolveImageUri(source as any, '../../secret.png')).toBeUndefined();
   });
+
+  it('strips query strings and fragments before resolving local image paths', () => {
+    const source = Uri.file('/workspace/docs/a.md');
+
+    expect(api.resolveImageUri(source as any, './demo.gif?v=1#preview')?.toString()).toBe(
+      'file:///workspace/docs/demo.gif'
+    );
+    expect(
+      api.resolveImageUri(
+        source as any,
+        'file:///workspace/docs/demo@2x.gif?cache=1#retina'
+      )?.toString()
+    ).toBe('file:///workspace/docs/demo@2x.gif');
+  });
 });

--- a/test/unit/linkResolver.test.ts
+++ b/test/unit/linkResolver.test.ts
@@ -42,4 +42,18 @@ describe('linkResolver', () => {
       )?.toString()
     ).toBe('file:///workspace/docs/demo@2x.gif');
   });
+
+  it('preserves SVG fragments in resolved local image URIs', () => {
+    const source = Uri.file('/workspace/docs/a.md');
+
+    expect(
+      api.resolveImageUri(source as any, './icons.svg?v=1#logo')?.toString()
+    ).toBe('file:///workspace/docs/icons.svg#logo');
+    expect(
+      api.resolveImageUri(
+        source as any,
+        'file:///workspace/docs/icons.svg?cache=1#logo'
+      )?.toString()
+    ).toBe('file:///workspace/docs/icons.svg#logo');
+  });
 });

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -354,9 +354,8 @@ describe('markdownPipeline', () => {
       'srcset="vscode-webview://file:///workspace/.omv-cache/image.gif 1x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/.omv-cache/image.gif 1x"'
+      'data-export-srcset="file:///workspace/.omv-cache/image.gif 1x, https://example.com/image@2x.gif 2x"'
     );
-    expect(result.html).not.toContain('https://example.com/image@2x.gif');
   });
 
   it('ignores img-like text inside other HTML attribute values', () => {
@@ -383,6 +382,63 @@ describe('markdownPipeline', () => {
     );
     expect(result.html).not.toContain('data-local-src=');
     expect(result.html).toContain('data-kind="example"');
+  });
+
+  it('does not rewrite img-like text inside raw-text HTML elements', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const input = [
+      '<textarea><img src="images/scroll.gif" alt="demo" /></textarea>',
+      '<script type="application/json">{"html":"<img src=\\"images/scroll.gif\\" alt=\\"demo\\" />"}</script>'
+    ].join('\n');
+
+    const result = renderMarkdown(input, {
+      sourceUri,
+      webview: webview as any,
+      allowHtml: true,
+      allowRemoteImages: false,
+      maxImageMB: 100
+    });
+
+    expect(result.html).toContain(
+      '<textarea><img src="images/scroll.gif" alt="demo" /></textarea>'
+    );
+    expect(result.html).toContain(
+      '<script type="application/json">{"html":"<img src=\\"images/scroll.gif\\" alt=\\"demo\\" />"}</script>'
+    );
+    expect(result.html).not.toContain('data-local-src=');
+  });
+
+  it('preserves blocked remote srcset candidates for export metadata', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/scroll.gif" srcset="images/scroll.gif 1x, https://cdn.example.com/scroll@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/docs/images/scroll.gif 1x"'
+    );
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, https://cdn.example.com/scroll@2x.gif 2x"'
+    );
   });
 
   it('preserves data URL srcset candidates when rewriting raw HTML images', () => {

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -192,9 +192,61 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain(
       'src="vscode-webview://file:///workspace/docs/images/scroll.gif"'
     );
-    expect(result.html).toContain('alt="a &gt; b"');
+    expect(result.html).toContain('alt="a > b"');
     expect(result.html).toContain(
       'data-local-src="file:///workspace/docs/images/scroll.gif"'
     );
+  });
+
+  it('preserves existing HTML entities when raw img tags are rewritten', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="https://example.com/image.gif?a=1&amp;b=2" alt="AT&amp;T" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: true,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'src="https://example.com/image.gif?a=1&amp;b=2"'
+    );
+    expect(result.html).toContain('alt="AT&amp;T"');
+    expect(result.html).not.toContain('&amp;amp;');
+  });
+
+  it('ignores img-like text inside other HTML attribute values', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      `<div data-template="<img src='images/scroll.gif' alt='demo'>" data-kind="example"></div>`,
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      `data-template="<img src='images/scroll.gif' alt='demo'>"`
+    );
+    expect(result.html).not.toContain('data-local-src=');
+    expect(result.html).toContain('data-kind="example"');
   });
 });

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -185,6 +185,34 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain('loading="lazy"');
   });
 
+  it('rewrites raw HTML img tags that rely on srcset alone', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img srcset="images/scroll.gif 1x, images/scroll@2x.gif 2x" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/docs/images/scroll.gif 1x, vscode-webview://file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
+    expect(result.html).toContain('loading="lazy"');
+  });
+
   it('rewrites raw HTML img tags when quoted attributes contain >', () => {
     const sourceUri = Uri.file('/workspace/docs/readme.md');
     const webview = {

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -212,6 +212,33 @@ describe('markdownPipeline', () => {
     );
   });
 
+  it('preserves SVG fragments when rewriting local raw HTML img tags', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/icons.svg?v=1#logo" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/docs/images/icons.svg#logo"'
+    );
+    expect(result.html).toContain(
+      'data-omv-local-src="file:///workspace/docs/images/icons.svg#logo"'
+    );
+  });
+
   it('rewrites raw HTML img tags that rely on srcset alone', () => {
     const sourceUri = Uri.file('/workspace/docs/readme.md');
     const webview = {

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -585,6 +585,10 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain(
       'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, https://cdn.example.com/scroll@2x.gif 2x"'
     );
+    expect(result.html).toContain(
+      'data-remote-src="https://cdn.example.com/scroll@2x.gif"'
+    );
+    expect(result.html).toContain('data-image-blocked="remote-disabled"');
   });
 
   it('marks srcset-only local raw HTML images as blocked when size filtering removes every candidate', () => {

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -238,6 +238,33 @@ describe('markdownPipeline', () => {
     );
   });
 
+  it('rewrites raw HTML img tags even when authors define data-max-mb', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/scroll.gif" data-max-mb="1" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/docs/images/scroll.gif"'
+    );
+    expect(result.html).toContain(
+      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+    );
+  });
+
   it('preserves local export metadata for size-blocked raw HTML images', () => {
     statSyncMock.mockReturnValue({ size: 101 * 1024 * 1024 });
 
@@ -345,6 +372,36 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain(
       'data-remote-src="https://example.com/image.gif"'
     );
+    expect(result.html).toContain('src=""');
+    expect(result.html).toContain('srcset=""');
+    expect(result.html).toContain(
+      'data-export-srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x"'
+    );
+  });
+
+  it('marks srcset-only remote raw HTML images as blocked when no preview source remains', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'data-remote-src="https://example.com/image.gif"'
+    );
+    expect(result.html).toContain('data-image-blocked="remote-disabled"');
     expect(result.html).toContain('src=""');
     expect(result.html).toContain('srcset=""');
     expect(result.html).toContain(
@@ -527,6 +584,38 @@ describe('markdownPipeline', () => {
     );
     expect(result.html).toContain(
       'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, https://cdn.example.com/scroll@2x.gif 2x"'
+    );
+  });
+
+  it('marks srcset-only local raw HTML images as blocked when size filtering removes every candidate', () => {
+    statSyncMock.mockReturnValue({ size: 101 * 1024 * 1024 });
+
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img srcset="images/scroll.gif 1x, images/scroll@2x.gif 2x" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'alt="demo (blocked: exceeds preview.maxImageMB)"'
+    );
+    expect(result.html).toContain('data-image-blocked="size-limit"');
+    expect(result.html).toContain('src=""');
+    expect(result.html).toContain('srcset=""');
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
   });
 

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -45,7 +45,7 @@ describe('markdownPipeline', () => {
     expect(result.toc[0]).toMatchObject({ id: 'title', text: 'Title' });
     expect(result.html).toContain('omv-mermaid');
     expect(result.html).toContain('data-math=');
-    expect(result.html).toContain('data-local-src="file:///workspace/docs/pic.png"');
+    expect(result.html).toContain('data-omv-local-src="file:///workspace/docs/pic.png"');
     expect(result.html).toContain(
       'src="vscode-webview://file:///workspace/docs/pic.png"'
     );
@@ -138,8 +138,8 @@ describe('markdownPipeline', () => {
       allowRemoteImages: false,
       maxImageMB: 8
     });
-    expect(blocked.html).toContain('data-remote-src="https://example.com/image.png"');
-    expect(blocked.html).toContain('data-image-blocked="remote-disabled"');
+    expect(blocked.html).toContain('data-omv-remote-src="https://example.com/image.png"');
+    expect(blocked.html).toContain('data-omv-image-blocked="remote-disabled"');
 
     const allowed = renderMarkdown(input, {
       sourceUri,
@@ -148,7 +148,7 @@ describe('markdownPipeline', () => {
       allowRemoteImages: true,
       maxImageMB: 8
     });
-    expect(allowed.html).not.toContain('data-remote-src=');
+    expect(allowed.html).not.toContain('data-omv-remote-src=');
     expect(allowed.html).toContain('src="https://example.com/image.png"');
   });
 
@@ -180,7 +180,7 @@ describe('markdownPipeline', () => {
       'src="vscode-webview://file:///workspace/docs/images/scroll.gif"'
     );
     expect(result.html).toContain(
-      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+      'data-omv-local-src="file:///workspace/docs/images/scroll.gif"'
     );
     expect(result.html).toContain('loading="lazy"');
   });
@@ -208,7 +208,7 @@ describe('markdownPipeline', () => {
       'srcset="vscode-webview://file:///workspace/docs/images/scroll.gif 1x, vscode-webview://file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
     expect(result.html).toContain('loading="lazy"');
   });
@@ -234,7 +234,7 @@ describe('markdownPipeline', () => {
     );
     expect(result.html).toContain('alt="a > b"');
     expect(result.html).toContain(
-      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+      'data-omv-local-src="file:///workspace/docs/images/scroll.gif"'
     );
   });
 
@@ -261,7 +261,34 @@ describe('markdownPipeline', () => {
       'src="vscode-webview://file:///workspace/docs/images/scroll.gif"'
     );
     expect(result.html).toContain(
-      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+      'data-omv-local-src="file:///workspace/docs/images/scroll.gif"'
+    );
+  });
+
+  it('preserves authored loading hints on raw HTML img tags', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/scroll.gif" loading="eager" decoding="sync" referrerpolicy="origin" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain('loading="eager"');
+    expect(result.html).toContain('decoding="sync"');
+    expect(result.html).toContain('referrerpolicy="origin"');
+    expect(result.html).toContain(
+      'data-omv-local-src="file:///workspace/docs/images/scroll.gif"'
     );
   });
 
@@ -287,13 +314,13 @@ describe('markdownPipeline', () => {
     );
 
     expect(result.html).toContain(
-      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+      'data-omv-local-src="file:///workspace/docs/images/scroll.gif"'
     );
-    expect(result.html).toContain('data-image-blocked="size-limit"');
+    expect(result.html).toContain('data-omv-image-blocked="size-limit"');
     expect(result.html).toContain('src=""');
     expect(result.html).toContain('srcset=""');
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
   });
 
@@ -320,7 +347,7 @@ describe('markdownPipeline', () => {
       'srcset="vscode-webview://file:///workspace/docs/images/scroll.gif 1x, vscode-webview://file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
   });
 
@@ -350,12 +377,12 @@ describe('markdownPipeline', () => {
     );
 
     expect(result.html).toContain(
-      'data-local-src="file:///workspace/docs/images/large.gif"'
+      'data-omv-local-src="file:///workspace/docs/images/large.gif"'
     );
     expect(result.html).toContain(
       'srcset="vscode-webview://file:///workspace/docs/images/small.gif 1x"'
     );
-    expect(result.html).not.toContain('data-image-blocked="size-limit"');
+    expect(result.html).not.toContain('data-omv-image-blocked="size-limit"');
     expect(result.html).not.toContain(
       'alt="demo (blocked: exceeds preview.maxImageMB)"'
     );
@@ -407,12 +434,12 @@ describe('markdownPipeline', () => {
     );
 
     expect(result.html).toContain(
-      'data-remote-src="https://example.com/image.gif"'
+      'data-omv-remote-src="https://example.com/image.gif"'
     );
     expect(result.html).toContain('src=""');
     expect(result.html).toContain('srcset=""');
     expect(result.html).toContain(
-      'data-export-srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x"'
+      'data-omv-export-srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x"'
     );
   });
 
@@ -436,13 +463,13 @@ describe('markdownPipeline', () => {
     );
 
     expect(result.html).toContain(
-      'data-remote-src="https://example.com/image.gif"'
+      'data-omv-remote-src="https://example.com/image.gif"'
     );
-    expect(result.html).toContain('data-image-blocked="remote-disabled"');
+    expect(result.html).toContain('data-omv-image-blocked="remote-disabled"');
     expect(result.html).toContain('src=""');
     expect(result.html).toContain('srcset=""');
     expect(result.html).toContain(
-      'data-export-srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x"'
+      'data-omv-export-srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x"'
     );
   });
 
@@ -466,7 +493,7 @@ describe('markdownPipeline', () => {
     );
 
     expect(result.html).toContain(
-      'data-remote-src="https://example.com/image.gif"'
+      'data-omv-remote-src="https://example.com/image.gif"'
     );
     expect(result.html).toContain(
       'src="vscode-webview://file:///workspace/docs/images/local.gif"'
@@ -475,7 +502,7 @@ describe('markdownPipeline', () => {
       'srcset="vscode-webview://file:///workspace/docs/images/local.gif 1x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
     );
   });
 
@@ -509,7 +536,7 @@ describe('markdownPipeline', () => {
       'srcset="vscode-webview://file:///workspace/.omv-cache/image.gif 1x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/.omv-cache/image.gif 1x, https://example.com/image@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/.omv-cache/image.gif 1x, https://example.com/image@2x.gif 2x"'
     );
   });
 
@@ -537,7 +564,7 @@ describe('markdownPipeline', () => {
       'srcset="vscode-webview://file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
     );
   });
 
@@ -563,7 +590,7 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain(
       `data-template="<img src='images/scroll.gif' alt='demo'>"`
     );
-    expect(result.html).not.toContain('data-local-src=');
+    expect(result.html).not.toContain('data-omv-local-src=');
     expect(result.html).toContain('data-kind="example"');
   });
 
@@ -594,7 +621,7 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain(
       '<script type="application/json">{"html":"<img src=\\"images/scroll.gif\\" alt=\\"demo\\" />"}</script>'
     );
-    expect(result.html).not.toContain('data-local-src=');
+    expect(result.html).not.toContain('data-omv-local-src=');
   });
 
   it('preserves blocked remote srcset candidates for export metadata', () => {
@@ -620,12 +647,12 @@ describe('markdownPipeline', () => {
       'srcset="vscode-webview://file:///workspace/docs/images/scroll.gif 1x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, https://cdn.example.com/scroll@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/docs/images/scroll.gif 1x, https://cdn.example.com/scroll@2x.gif 2x"'
     );
     expect(result.html).toContain(
-      'data-remote-src="https://cdn.example.com/scroll@2x.gif"'
+      'data-omv-remote-src="https://cdn.example.com/scroll@2x.gif"'
     );
-    expect(result.html).toContain('data-image-blocked="remote-disabled"');
+    expect(result.html).toContain('data-omv-image-blocked="remote-disabled"');
   });
 
   it('marks srcset-only local raw HTML images as blocked when size filtering removes every candidate', () => {
@@ -652,11 +679,11 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain(
       'alt="demo (blocked: exceeds preview.maxImageMB)"'
     );
-    expect(result.html).toContain('data-image-blocked="size-limit"');
+    expect(result.html).toContain('data-omv-image-blocked="size-limit"');
     expect(result.html).toContain('src=""');
     expect(result.html).toContain('srcset=""');
     expect(result.html).toContain(
-      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+      'data-omv-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
   });
 
@@ -683,7 +710,7 @@ describe('markdownPipeline', () => {
       'srcset="data:image/svg+xml;base64,PHN2Zy8+ 1x, vscode-webview://file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
     expect(result.html).toContain(
-      'data-export-srcset="data:image/svg+xml;base64,PHN2Zy8+ 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+      'data-omv-export-srcset="data:image/svg+xml;base64,PHN2Zy8+ 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
   });
 });

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -185,6 +185,33 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain('loading="lazy"');
   });
 
+  it('resolves local raw HTML img tags with query strings and fragments', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/scroll.gif?v=1#demo" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/docs/images/scroll.gif"'
+    );
+    expect(result.html).toContain(
+      'data-omv-local-src="file:///workspace/docs/images/scroll.gif"'
+    );
+  });
+
   it('rewrites raw HTML img tags that rely on srcset alone', () => {
     const sourceUri = Uri.file('/workspace/docs/readme.md');
     const webview = {
@@ -211,6 +238,33 @@ describe('markdownPipeline', () => {
       'data-omv-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
     expect(result.html).toContain('loading="lazy"');
+  });
+
+  it('resolves local raw HTML srcset candidates with query strings and fragments', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img srcset="images/scroll.gif?v=1 1x, images/scroll@2x.gif#retina 2x" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/docs/images/scroll.gif 1x, vscode-webview://file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
+    expect(result.html).toContain(
+      'data-omv-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
   });
 
   it('rewrites raw HTML img tags when quoted attributes contain >', () => {

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -33,7 +33,10 @@ describe('markdownPipeline', () => {
     expect(result.toc[0]).toMatchObject({ id: 'title', text: 'Title' });
     expect(result.html).toContain('omv-mermaid');
     expect(result.html).toContain('data-math=');
-    expect(result.html).toContain('data-local-src=');
+    expect(result.html).toContain('data-local-src="file:///workspace/docs/pic.png"');
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/docs/pic.png"'
+    );
     expect(result.html).toContain('task-list-item');
     expect(result.html).toContain('<dl>');
     expect(result.html).toContain('footnote');

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -1,13 +1,25 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let renderMarkdown: any;
 let Uri: any;
+const statSyncMock = vi.fn(() => {
+  throw new Error('ENOENT');
+});
 
 beforeAll(async () => {
   const mock = await import('./helpers/vscodeMock');
   Uri = mock.Uri;
   vi.doMock('vscode', () => mock.createVscodeMock('/workspace'));
+  vi.doMock('node:fs', () => ({
+    statSync: statSyncMock
+  }));
   ({ renderMarkdown } = await import('../../src/extension/preview/markdown/markdownPipeline'));
+});
+
+beforeEach(() => {
+  statSyncMock.mockImplementation(() => {
+    throw new Error('ENOENT');
+  });
 });
 
 describe('markdownPipeline', () => {
@@ -195,6 +207,58 @@ describe('markdownPipeline', () => {
     expect(result.html).toContain('alt="a > b"');
     expect(result.html).toContain(
       'data-local-src="file:///workspace/docs/images/scroll.gif"'
+    );
+  });
+
+  it('preserves local export metadata for size-blocked raw HTML images', () => {
+    statSyncMock.mockReturnValue({ size: 101 * 1024 * 1024 });
+
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown('<img src="images/scroll.gif" alt="demo" />', {
+      sourceUri,
+      webview: webview as any,
+      allowHtml: true,
+      allowRemoteImages: false,
+      maxImageMB: 100
+    });
+
+    expect(result.html).toContain(
+      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+    );
+    expect(result.html).toContain('data-image-blocked="size-limit"');
+    expect(result.html).toContain('src=""');
+  });
+
+  it('rewrites raw HTML srcset candidates and preserves export srcset', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/scroll.gif" srcset="images/scroll.gif 1x, images/scroll@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/docs/images/scroll.gif 1x, vscode-webview://file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
     );
   });
 

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -136,4 +136,37 @@ describe('markdownPipeline', () => {
     expect(allowed.html).not.toContain('data-remote-src=');
     expect(allowed.html).toContain('src="https://example.com/image.png"');
   });
+
+  it('rewrites local raw HTML img tags to webview URIs', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const input = [
+      '<table>',
+      '  <tr>',
+      '    <td><img src="images/scroll.gif" alt="demo" /></td>',
+      '  </tr>',
+      '</table>'
+    ].join('\n');
+
+    const result = renderMarkdown(input, {
+      sourceUri,
+      webview: webview as any,
+      allowHtml: true,
+      allowRemoteImages: false,
+      maxImageMB: 100
+    });
+
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/docs/images/scroll.gif"'
+    );
+    expect(result.html).toContain(
+      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+    );
+    expect(result.html).toContain('loading="lazy"');
+  });
 });

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -172,4 +172,29 @@ describe('markdownPipeline', () => {
     );
     expect(result.html).toContain('loading="lazy"');
   });
+
+  it('rewrites raw HTML img tags when quoted attributes contain >', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown('<img src="images/scroll.gif" alt="a > b" />', {
+      sourceUri,
+      webview: webview as any,
+      allowHtml: true,
+      allowRemoteImages: false,
+      maxImageMB: 100
+    });
+
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/docs/images/scroll.gif"'
+    );
+    expect(result.html).toContain('alt="a &gt; b"');
+    expect(result.html).toContain(
+      'data-local-src="file:///workspace/docs/images/scroll.gif"'
+    );
+  });
 });

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -319,7 +319,9 @@ describe('markdownPipeline', () => {
     );
     expect(result.html).toContain('src=""');
     expect(result.html).toContain('srcset=""');
-    expect(result.html).not.toContain('https://example.com/image@2x.gif');
+    expect(result.html).toContain(
+      'data-export-srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x"'
+    );
   });
 
   it('rewrites raw HTML srcset when a remote image override exists', () => {
@@ -381,5 +383,32 @@ describe('markdownPipeline', () => {
     );
     expect(result.html).not.toContain('data-local-src=');
     expect(result.html).toContain('data-kind="example"');
+  });
+
+  it('preserves data URL srcset candidates when rewriting raw HTML images', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/scroll.gif" srcset="data:image/svg+xml;base64,PHN2Zy8+ 1x, images/scroll@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'srcset="data:image/svg+xml;base64,PHN2Zy8+ 1x, vscode-webview://file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
+    expect(result.html).toContain(
+      'data-export-srcset="data:image/svg+xml;base64,PHN2Zy8+ 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
   });
 });

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -391,6 +391,34 @@ describe('markdownPipeline', () => {
     );
   });
 
+  it('rewrites raw HTML srcset even when the primary src stays remote', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="https://example.com/image.gif" srcset="images/local.gif 1x, https://example.com/image@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: true,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain('src="https://example.com/image.gif"');
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
+    );
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
+    );
+  });
+
   it('ignores img-like text inside other HTML attribute values', () => {
     const sourceUri = Uri.file('/workspace/docs/readme.md');
     const webview = {

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -220,19 +220,26 @@ describe('markdownPipeline', () => {
       }
     };
 
-    const result = renderMarkdown('<img src="images/scroll.gif" alt="demo" />', {
-      sourceUri,
-      webview: webview as any,
-      allowHtml: true,
-      allowRemoteImages: false,
-      maxImageMB: 100
-    });
+    const result = renderMarkdown(
+      '<img src="images/scroll.gif" alt="demo" srcset="images/scroll.gif 1x, images/scroll@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
 
     expect(result.html).toContain(
       'data-local-src="file:///workspace/docs/images/scroll.gif"'
     );
     expect(result.html).toContain('data-image-blocked="size-limit"');
     expect(result.html).toContain('src=""');
+    expect(result.html).toContain('srcset=""');
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/docs/images/scroll.gif 1x, file:///workspace/docs/images/scroll@2x.gif 2x"'
+    );
   });
 
   it('rewrites raw HTML srcset candidates and preserves export srcset', () => {
@@ -286,6 +293,68 @@ describe('markdownPipeline', () => {
     );
     expect(result.html).toContain('alt="AT&amp;T"');
     expect(result.html).not.toContain('&amp;amp;');
+  });
+
+  it('clears remote raw HTML srcset when remote images are disabled', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="https://example.com/image.gif" srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'data-remote-src="https://example.com/image.gif"'
+    );
+    expect(result.html).toContain('src=""');
+    expect(result.html).toContain('srcset=""');
+    expect(result.html).not.toContain('https://example.com/image@2x.gif');
+  });
+
+  it('rewrites raw HTML srcset when a remote image override exists', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const cachedUri = Uri.file('/workspace/.omv-cache/image.gif');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="https://example.com/image.gif" srcset="https://example.com/image.gif 1x, https://example.com/image@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        remoteImageOverrides: new Map([
+          ['https://example.com/image.gif', cachedUri]
+        ]),
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/.omv-cache/image.gif"'
+    );
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/.omv-cache/image.gif 1x"'
+    );
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/.omv-cache/image.gif 1x"'
+    );
+    expect(result.html).not.toContain('https://example.com/image@2x.gif');
   });
 
   it('ignores img-like text inside other HTML attribute values', () => {

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -324,6 +324,39 @@ describe('markdownPipeline', () => {
     );
   });
 
+  it('keeps safe raw HTML srcset candidates when a remote primary src is blocked', () => {
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="https://example.com/image.gif" srcset="images/local.gif 1x, https://example.com/image@2x.gif 2x" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'data-remote-src="https://example.com/image.gif"'
+    );
+    expect(result.html).toContain(
+      'src="vscode-webview://file:///workspace/docs/images/local.gif"'
+    );
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/docs/images/local.gif 1x"'
+    );
+    expect(result.html).toContain(
+      'data-export-srcset="file:///workspace/docs/images/local.gif 1x, https://example.com/image@2x.gif 2x"'
+    );
+  });
+
   it('rewrites raw HTML srcset when a remote image override exists', () => {
     const sourceUri = Uri.file('/workspace/docs/readme.md');
     const cachedUri = Uri.file('/workspace/.omv-cache/image.gif');

--- a/test/unit/markdownPipeline.test.ts
+++ b/test/unit/markdownPipeline.test.ts
@@ -324,6 +324,43 @@ describe('markdownPipeline', () => {
     );
   });
 
+  it('does not mark raw HTML images as blocked when srcset still has a usable candidate', () => {
+    statSyncMock.mockImplementation((targetPath: string) => ({
+      size: targetPath.endsWith('large.gif')
+        ? 101 * 1024 * 1024
+        : 1024
+    }));
+
+    const sourceUri = Uri.file('/workspace/docs/readme.md');
+    const webview = {
+      asWebviewUri(uri: { toString(): string }) {
+        return { toString: () => `vscode-webview://${uri.toString()}` };
+      }
+    };
+
+    const result = renderMarkdown(
+      '<img src="images/large.gif" srcset="images/small.gif 1x" alt="demo" />',
+      {
+        sourceUri,
+        webview: webview as any,
+        allowHtml: true,
+        allowRemoteImages: false,
+        maxImageMB: 100
+      }
+    );
+
+    expect(result.html).toContain(
+      'data-local-src="file:///workspace/docs/images/large.gif"'
+    );
+    expect(result.html).toContain(
+      'srcset="vscode-webview://file:///workspace/docs/images/small.gif 1x"'
+    );
+    expect(result.html).not.toContain('data-image-blocked="size-limit"');
+    expect(result.html).not.toContain(
+      'alt="demo (blocked: exceeds preview.maxImageMB)"'
+    );
+  });
+
   it('preserves existing HTML entities when raw img tags are rewritten', () => {
     const sourceUri = Uri.file('/workspace/docs/readme.md');
     const webview = {

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -664,7 +664,7 @@ describe('PreviewController custom CSS', () => {
     );
 
     expect(html).toContain(
-      '<img data-local-src="file:///workspace-a/images/demo.gif" alt="a &gt; b" src="file:///workspace-a/images/demo.gif" />'
+      '<img data-local-src="file:///workspace-a/images/demo.gif" alt="a > b" src="file:///workspace-a/images/demo.gif" />'
     );
   });
 

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -687,6 +687,25 @@ describe('PreviewController custom CSS', () => {
     );
   });
 
+  it('restores blocked remote image sources and srcset for export', async () => {
+    const { module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a']
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    const html = (controller as any).rewriteLocalImageSourcesForExport(
+      '<p><img data-remote-src="https://example.com/demo.gif" src="" data-export-srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" srcset="" /></p>'
+    );
+
+    expect(html).toContain(
+      '<img data-remote-src="https://example.com/demo.gif" src="https://example.com/demo.gif" data-export-srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" />'
+    );
+  });
+
   it('hydrates new webviews with the saved preview UI toggle state', async () => {
     const { globalState, module } = await loadPreviewPanelTestModule({
       workspaceFolderPaths: ['/workspace-a'],

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -668,6 +668,25 @@ describe('PreviewController custom CSS', () => {
     );
   });
 
+  it('restores blocked local image sources and srcset for export', async () => {
+    const { module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a']
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    const html = (controller as any).rewriteLocalImageSourcesForExport(
+      '<p><img data-local-src="file:///workspace-a/images/demo.gif" src="" data-export-srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" srcset="" /></p>'
+    );
+
+    expect(html).toContain(
+      '<img data-local-src="file:///workspace-a/images/demo.gif" src="file:///workspace-a/images/demo.gif" data-export-srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" />'
+    );
+  });
+
   it('hydrates new webviews with the saved preview UI toggle state', async () => {
     const { globalState, module } = await loadPreviewPanelTestModule({
       workspaceFolderPaths: ['/workspace-a'],

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -649,6 +649,25 @@ describe('PreviewController custom CSS', () => {
     );
   });
 
+  it('rewrites local image sources for export when quoted attributes contain >', async () => {
+    const { module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a']
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    const html = (controller as any).rewriteLocalImageSourcesForExport(
+      '<p><img data-local-src="file:///workspace-a/images/demo.gif" alt="a > b" src="vscode-webview://file:///workspace-a/images/demo.gif" /></p>'
+    );
+
+    expect(html).toContain(
+      '<img data-local-src="file:///workspace-a/images/demo.gif" alt="a &gt; b" src="file:///workspace-a/images/demo.gif" />'
+    );
+  });
+
   it('hydrates new webviews with the saved preview UI toggle state', async () => {
     const { globalState, module } = await loadPreviewPanelTestModule({
       workspaceFolderPaths: ['/workspace-a'],

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -245,6 +245,7 @@ function createPreviewPanelTestContext(options: {
   };
 
   const fsMock = {
+    stat: vi.fn().mockResolvedValue({ size: 1024 }),
     readFile: vi
       .fn()
       .mockResolvedValue(options.baseCssText ?? 'body { color: black; }')
@@ -723,6 +724,26 @@ describe('PreviewController custom CSS', () => {
     expect(html).toContain(
       '<img src="https://cdn.example.com/demo.gif" data-remote-src="hero" alt="demo" />'
     );
+  });
+
+  it('preserves SVG fragments when embedding local images for export', async () => {
+    const { fsMock, module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a']
+    });
+
+    fsMock.readFile.mockResolvedValueOnce(Buffer.from('<svg />'));
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    const html = await (controller as any).embedLocalImages(
+      '<p><img data-omv-local-src="file:///workspace-a/images/icons.svg#logo" src="file:///workspace-a/images/icons.svg#logo" /></p>',
+      24
+    );
+
+    expect(html).toContain('src="data:image/svg+xml;base64,PHN2ZyAvPg==#logo"');
   });
 
   it('hydrates new webviews with the saved preview UI toggle state', async () => {

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -630,6 +630,25 @@ describe('PreviewController custom CSS', () => {
     );
   });
 
+  it('rewrites local image sources for export regardless of attribute order', async () => {
+    const { module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a']
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    const html = (controller as any).rewriteLocalImageSourcesForExport(
+      '<p><img src="vscode-webview://file:///workspace-a/images/demo.gif" alt="demo" data-local-src="file:///workspace-a/images/demo.gif" /></p>'
+    );
+
+    expect(html).toContain(
+      '<img src="file:///workspace-a/images/demo.gif" alt="demo" data-local-src="file:///workspace-a/images/demo.gif" />'
+    );
+  });
+
   it('hydrates new webviews with the saved preview UI toggle state', async () => {
     const { globalState, module } = await loadPreviewPanelTestModule({
       workspaceFolderPaths: ['/workspace-a'],

--- a/test/unit/previewPanel.test.ts
+++ b/test/unit/previewPanel.test.ts
@@ -641,11 +641,11 @@ describe('PreviewController custom CSS', () => {
     } as any);
 
     const html = (controller as any).rewriteLocalImageSourcesForExport(
-      '<p><img src="vscode-webview://file:///workspace-a/images/demo.gif" alt="demo" data-local-src="file:///workspace-a/images/demo.gif" /></p>'
+      '<p><img src="vscode-webview://file:///workspace-a/images/demo.gif" alt="demo" data-omv-local-src="file:///workspace-a/images/demo.gif" /></p>'
     );
 
     expect(html).toContain(
-      '<img src="file:///workspace-a/images/demo.gif" alt="demo" data-local-src="file:///workspace-a/images/demo.gif" />'
+      '<img src="file:///workspace-a/images/demo.gif" alt="demo" data-omv-local-src="file:///workspace-a/images/demo.gif" />'
     );
   });
 
@@ -660,11 +660,11 @@ describe('PreviewController custom CSS', () => {
     } as any);
 
     const html = (controller as any).rewriteLocalImageSourcesForExport(
-      '<p><img data-local-src="file:///workspace-a/images/demo.gif" alt="a > b" src="vscode-webview://file:///workspace-a/images/demo.gif" /></p>'
+      '<p><img data-omv-local-src="file:///workspace-a/images/demo.gif" alt="a > b" src="vscode-webview://file:///workspace-a/images/demo.gif" /></p>'
     );
 
     expect(html).toContain(
-      '<img data-local-src="file:///workspace-a/images/demo.gif" alt="a > b" src="file:///workspace-a/images/demo.gif" />'
+      '<img data-omv-local-src="file:///workspace-a/images/demo.gif" alt="a > b" src="file:///workspace-a/images/demo.gif" />'
     );
   });
 
@@ -679,11 +679,11 @@ describe('PreviewController custom CSS', () => {
     } as any);
 
     const html = (controller as any).rewriteLocalImageSourcesForExport(
-      '<p><img data-local-src="file:///workspace-a/images/demo.gif" src="" data-export-srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" srcset="" /></p>'
+      '<p><img data-omv-local-src="file:///workspace-a/images/demo.gif" src="" data-omv-export-srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" srcset="" /></p>'
     );
 
     expect(html).toContain(
-      '<img data-local-src="file:///workspace-a/images/demo.gif" src="file:///workspace-a/images/demo.gif" data-export-srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" />'
+      '<img data-omv-local-src="file:///workspace-a/images/demo.gif" src="file:///workspace-a/images/demo.gif" data-omv-export-srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" srcset="file:///workspace-a/images/demo.gif 1x, file:///workspace-a/images/demo@2x.gif 2x" />'
     );
   });
 
@@ -698,11 +698,30 @@ describe('PreviewController custom CSS', () => {
     } as any);
 
     const html = (controller as any).rewriteLocalImageSourcesForExport(
-      '<p><img data-remote-src="https://example.com/demo.gif" src="" data-export-srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" srcset="" /></p>'
+      '<p><img data-omv-remote-src="https://example.com/demo.gif" src="" data-omv-export-srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" srcset="" /></p>'
     );
 
     expect(html).toContain(
-      '<img data-remote-src="https://example.com/demo.gif" src="https://example.com/demo.gif" data-export-srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" />'
+      '<img data-omv-remote-src="https://example.com/demo.gif" src="https://example.com/demo.gif" data-omv-export-srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" srcset="https://example.com/demo.gif 1x, https://example.com/demo@2x.gif 2x" />'
+    );
+  });
+
+  it('ignores authored generic data-remote-src during export rewriting', async () => {
+    const { module } = await loadPreviewPanelTestModule({
+      workspaceFolderPaths: ['/workspace-a']
+    });
+
+    const controller = new module.PreviewController({
+      extensionUri: Uri.file('/extension'),
+      globalStorageUri: Uri.file('/global-storage')
+    } as any);
+
+    const html = (controller as any).rewriteLocalImageSourcesForExport(
+      '<p><img src="https://cdn.example.com/demo.gif" data-remote-src="hero" alt="demo" /></p>'
+    );
+
+    expect(html).toContain(
+      '<img src="https://cdn.example.com/demo.gif" data-remote-src="hero" alt="demo" />'
     );
   });
 

--- a/test/unit/remoteImageAttrs.test.ts
+++ b/test/unit/remoteImageAttrs.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  markRemoteImagePreviewHidden,
+  restoreRemoteImageExportVisibility
+} from '../../src/webview-ui/app/remoteImageAttrs';
+
+class FakeImageElement {
+  private readonly attrs = new Map<string, string>();
+  private hiddenValue = false;
+
+  constructor(initialAttrs: Record<string, string> = {}) {
+    for (const [name, value] of Object.entries(initialAttrs)) {
+      this.setAttribute(name, value);
+    }
+  }
+
+  get hidden(): boolean {
+    return this.hiddenValue;
+  }
+
+  set hidden(value: boolean) {
+    this.hiddenValue = value;
+    if (value) {
+      this.attrs.set('hidden', '');
+    } else {
+      this.attrs.delete('hidden');
+    }
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attrs.has(name);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attrs.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attrs.set(name, value);
+    if (name === 'hidden') {
+      this.hiddenValue = true;
+    }
+  }
+
+  removeAttribute(name: string): void {
+    this.attrs.delete(name);
+    if (name === 'hidden') {
+      this.hiddenValue = false;
+    }
+  }
+}
+
+describe('remoteImageAttrs', () => {
+  it('preserves authored hidden attrs when restoring export visibility', () => {
+    const image = new FakeImageElement({ hidden: '' });
+
+    markRemoteImagePreviewHidden(image);
+    restoreRemoteImageExportVisibility(image);
+
+    expect(image.hidden).toBe(true);
+    expect(image.hasAttribute('hidden')).toBe(true);
+    expect(image.getAttribute('aria-hidden')).toBeNull();
+    expect(image.getAttribute('data-omv-preview-hidden')).toBeNull();
+    expect(
+      image.getAttribute('data-omv-preview-restore-aria-hidden')
+    ).toBeNull();
+  });
+
+  it('restores preview-added hidden and original aria-hidden values', () => {
+    const image = new FakeImageElement({ 'aria-hidden': 'false' });
+
+    markRemoteImagePreviewHidden(image);
+    restoreRemoteImageExportVisibility(image);
+
+    expect(image.hidden).toBe(false);
+    expect(image.hasAttribute('hidden')).toBe(false);
+    expect(image.getAttribute('aria-hidden')).toBe('false');
+    expect(image.getAttribute('data-omv-preview-hidden')).toBeNull();
+    expect(
+      image.getAttribute('data-omv-preview-restore-aria-hidden')
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR fixes README/demo GIF rendering when images are authored in raw HTML `<img>` tags and rolls the extension forward to `0.3.0`.

## What changed

- rewrite local raw HTML `<img>` `src` and `srcset` values to webview-safe URIs
- preserve export metadata so HTML/PDF export can restore original local/remote image sources
- support blocked/size-limited images consistently for raw HTML images, including `srcset`-only cases
- preserve SVG fragments when rewriting and embedding local images
- keep remote-image placeholder behaviour compatible with export snapshots
- persist preview UI visibility state for search and table of contents
- raise the default `offlineMarkdownViewer.preview.maxImageMB` from `8` MB to `24` MB so bundled demo GIFs render without extra config
- update `README.md`, `CHANGELOG.md`, and package version to `0.3.0`

## Why

The README uses table-based raw HTML image tags for GIF demos. Those images were not being rewritten the same way as Markdown image syntax, so they could fail to render in the preview/export flow. This change brings raw HTML image handling in line with the rest of the preview pipeline.

## Testing

- added unit coverage for raw HTML image tag parsing and srcset rewriting
- added unit coverage for export rewriting and remote image visibility restoration
- ran `npm test`
- ran `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search panel visibility now persists across refresh and reopen
  * Preview table-of-contents visibility changes are saved and restored

* **Improvements**
  * Local image paths in raw HTML are now correctly rewritten for preview rendering
  * Default maximum image file size limit increased from 8 MB to 24 MB

<!-- end of auto-generated comment: release notes by coderabbit.ai -->